### PR TITLE
0.1.3 - Who templates the templates?

### DIFF
--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -13,10 +13,10 @@ export class DishonoredCharacterSheet extends ActorSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "actor"],
+            classes: ["dishonored", "sheet", "character"],
             template: "systems/FVTT-Dishonored/templates/actors/character-sheet.html",
             width: 700,
-            height: 600,
+            height: 740,
             dragDrop: [{
                 dragSelector: ".item-list .item",
                 dropSelector: null

--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -16,7 +16,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
             classes: ["dishonored", "sheet", "character"],
             template: "systems/FVTT-Dishonored/templates/actors/character-sheet.html",
             width: 700,
-            height: 740,
+            height: 735,
             dragDrop: [{
                 dragSelector: ".item-list .item",
                 dropSelector: null
@@ -30,9 +30,6 @@ export class DishonoredCharacterSheet extends ActorSheet {
     getData() {
         const data = super.getData();
         data.dtypes = ["String", "Number", "Boolean"];
-        for (let attr of Object.values(data.data.attributes)) {
-            attr.isCheckbox = attr.dtype === "Boolean";
-        }
 
         //Ensure skill and style values don't weigh over the max of 8 and minimum of 4.
         if (data.data.skills.fight.value > 8) data.data.skills.fight.value = 8;

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -13,15 +13,10 @@ export class DishonoredNPCSheet extends ActorSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "actor"],
-            template: "systems/FVTT-Dishonored/templates/actors/character-sheet.html",
+            classes: ["dishonored", "sheet", "npc"],
+            template: "systems/FVTT-Dishonored/templates/actors/npc-sheet.html",
             width: 700,
-            height: 600,
-            tabs: [{
-                navSelector: ".sheet-tabs",
-                contentSelector: ".sheet-body",
-                initial: "description"
-            }],
+            height: 660,
             dragDrop: [{
                 dragSelector: ".item-list .item",
                 dropSelector: null
@@ -35,9 +30,6 @@ export class DishonoredNPCSheet extends ActorSheet {
     getData() {
         const data = super.getData();
         data.dtypes = ["String", "Number", "Boolean"];
-        for (let attr of Object.values(data.data.attributes)) {
-            attr.isCheckbox = attr.dtype === "Boolean";
-        }
 
         //Ensure skill and style values don't weigh over the max of 8 and minimum of 4.
         if (data.data.skills.fight.value > 8) data.data.skills.fight.value = 8;
@@ -52,7 +44,6 @@ export class DishonoredNPCSheet extends ActorSheet {
         if (data.data.styles.forcefully.value > 8) data.data.styles.forcefully.value = 8;
         if (data.data.styles.quietly.value > 8) data.data.styles.quietly.value = 8;
         if (data.data.styles.swiftly.value > 8) data.data.styles.swiftly.value = 8;
-        if (data.data.void.value > data.data.void.max) data.data.void.value = data.data.void.max;
         if (data.data.skills.fight.value < 4) data.data.skills.fight.value = 4;
         if (data.data.skills.move.value < 4) data.data.skills.move.value = 4;
         if (data.data.skills.study.value < 4) data.data.skills.study.value = 4;
@@ -65,8 +56,6 @@ export class DishonoredNPCSheet extends ActorSheet {
         if (data.data.styles.forcefully.value < 4) data.data.styles.forcefully.value = 4;
         if (data.data.styles.quietly.value < 4) data.data.styles.quietly.value = 4;
         if (data.data.styles.swiftly.value < 4) data.data.styles.swiftly.value = 4;
-        if (data.data.void.value < 0) data.data.void.value = 0;
-        if (data.data.void.max < 1) data.data.void.value = 1;
 
         return data;
     }
@@ -76,18 +65,6 @@ export class DishonoredNPCSheet extends ActorSheet {
     /** @override */
     activateListeners(html) {
         super.activateListeners(html);
-
-        var voidpointsmax = document.getElementById('max-void').value;
-        var i;
-        for (i = 1; i <= voidpointsmax; i++) {
-            var div = document.createElement("DIV");
-            div.className = "voidbox";
-            div.id = "void-" + i;
-            div.innerHTML = i;
-            div.style = "width: calc(100% / " + document.getElementById('max-void').value + ");"
-            document.getElementById('bar-void-renderer').appendChild(div);
-            //   <div class="voidbox" id="void-1">1</div>
-        }
 
         // Everything below here is only needed if the sheet is editable
         if (!this.options.editable) return;
@@ -129,30 +106,6 @@ export class DishonoredNPCSheet extends ActorSheet {
             li.slideUp(200, () => this.render(false));
         });
 
-        html.find('[id^="mom"]').click(ev => {
-            var newTotalObject = $(ev.currentTarget)[0];
-            var newTotal = newTotalObject.id.substring(4);
-            if (newTotalObject.getAttribute("data-value") == 1) {
-                var nextCheck = 'mom-' + (parseInt(newTotal) + 1);
-                if (!document.getElementById(nextCheck) || document.getElementById(nextCheck).getAttribute("data-value") != 1) {
-                    document.getElementById('total-mom').value = document.getElementById('total-mom').value - 1;
-                    barRenderer();
-                } else {
-                    var total = document.getElementById('total-mom').value;
-                    if (total != newTotal) {
-                        document.getElementById('total-mom').value = newTotal;
-                        barRenderer();
-                    }
-                }
-            } else {
-                var total = document.getElementById('total-mom').value;
-                if (total != newTotal) {
-                    document.getElementById('total-mom').value = newTotal;
-                    barRenderer();
-                }
-            }
-        });
-
         html.find('[id^="stress"]').click(ev => {
             var newTotalObject = $(ev.currentTarget)[0];
             var newTotal = newTotalObject.id.substring(7);
@@ -178,43 +131,6 @@ export class DishonoredNPCSheet extends ActorSheet {
                     this.submit();
                 }
             }
-        });
-
-        html.find('[id^="void"]').click(ev => {
-            var newTotalObject = $(ev.currentTarget)[0];
-            var newTotal = newTotalObject.id.replace(/\D/g, '');
-            if (newTotalObject.getAttribute("data-value") == 1) {
-                var nextCheck = 'void-' + (parseInt(newTotal) + 1);
-                if (!document.getElementById(nextCheck) || document.getElementById(nextCheck).getAttribute("data-value") != 1) {
-                    document.getElementById('total-void').value = document.getElementById('total-void').value - 1;
-                    barRenderer();
-                    this.submit();
-                } else {
-                    var total = document.getElementById('total-void').value;
-                    if (total != newTotal) {
-                        document.getElementById('total-void').value = newTotal;
-                        barRenderer();
-                        this.submit();
-                    }
-                }
-            } else {
-                var total = document.getElementById('total-void').value;
-                if (total != newTotal) {
-                    document.getElementById('total-void').value = newTotal;
-                    barRenderer();
-                    this.submit();
-                }
-            }
-        });
-
-        html.find('[id="decrease-void-max"]').click(ev => {
-            document.getElementById('max-void').value--;
-            this.submit();
-        });
-
-        html.find('[id="increase-void-max"]').click(ev => {
-            document.getElementById('max-void').value++;
-            this.submit();
         });
 
         html.find('.skill-roll-selector').click(ev => {
@@ -257,22 +173,8 @@ export class DishonoredNPCSheet extends ActorSheet {
             this.rollSkillTest(event, checkTarget, selectedSkill, selectedStyle);
         });
 
-
-
         function barRenderer() {
             var i;
-            var voidpointsmax = document.getElementById('max-void').value;
-            for (i = 0; i < 6; i++) {
-                if (i + 1 <= document.getElementById('total-mom').value) {
-                    html.find('[id^="mom"]')[i].setAttribute("data-value", "1");
-                    html.find('[id^="mom"]')[i].style.backgroundColor = "#191813";
-                    html.find('[id^="mom"]')[i].style.color = "#ffffff";
-                } else {
-                    html.find('[id^="mom"]')[i].setAttribute("data-value", "0");
-                    html.find('[id^="mom"]')[i].style.backgroundColor = "";
-                    html.find('[id^="mom"]')[i].style.color = "";
-                }
-            }
             for (i = 0; i < 12; i++) {
                 if (i + 1 <= document.getElementById('total-stress').value) {
                     html.find('[id^="stress"]')[i].setAttribute("data-value", "1");
@@ -282,17 +184,6 @@ export class DishonoredNPCSheet extends ActorSheet {
                     html.find('[id^="stress"]')[i].setAttribute("data-value", "0");
                     html.find('[id^="stress"]')[i].style.backgroundColor = "";
                     html.find('[id^="stress"]')[i].style.color = "";
-                }
-            }
-            for (i = 0; i < voidpointsmax; i++) {
-                if (i + 1 <= document.getElementById('total-void').value) {
-                    html.find('[id^="void"]')[i].setAttribute("data-value", "1");
-                    html.find('[id^="void"]')[i].style.backgroundColor = "#191813";
-                    html.find('[id^="void"]')[i].style.color = "#ffffff";
-                } else {
-                    html.find('[id^="void"]')[i].setAttribute("data-value", "0");
-                    html.find('[id^="void"]')[i].style.backgroundColor = "";
-                    html.find('[id^="void"]')[i].style.color = "";
                 }
             }
 

--- a/module/dishonored.js
+++ b/module/dishonored.js
@@ -11,6 +11,12 @@ import {
 import {
     DishonoredNPCSheet
 } from "./actors/sheets/npc-sheet.js";
+import {
+    DishonoredTalentSheet
+} from "./items/talent-sheet.js";
+import {
+    DishonoredFocusSheet
+} from "./items/focus-sheet.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -42,7 +48,14 @@ Hooks.once("init", async function() {
     // });
     Items.unregisterSheet("core", ItemSheet);
     Items.registerSheet("dishonored", DishonoredItemSheet, {
+        types: ["item"],
         makeDefault: true
+    });
+    Items.registerSheet("dishonored", DishonoredTalentSheet, {
+        types: ["talent"],
+    });
+    Items.registerSheet("dishonored", DishonoredFocusSheet, {
+        types: ["focus"],
     });
 
     // Register system settings

--- a/module/dishonored.js
+++ b/module/dishonored.js
@@ -1,8 +1,5 @@
 // Import Modules
 import {
-    DishonoredItemSheet
-} from "./items/item-sheet.js";
-import {
     DishonoredActor
 } from "./actors/actor.js";
 import {
@@ -12,11 +9,29 @@ import {
     DishonoredNPCSheet
 } from "./actors/sheets/npc-sheet.js";
 import {
-    DishonoredTalentSheet
-} from "./items/talent-sheet.js";
+    DishonoredItemSheet
+} from "./items/item-sheet.js";
 import {
     DishonoredFocusSheet
 } from "./items/focus-sheet.js";
+import {
+    DishonoredBonecharmSheet
+} from "./items/bonecharm-sheet.js";
+import {
+    DishonoredWeaponSheet
+} from "./items/weapon-sheet.js";
+import {
+    DishonoredArmorSheet
+} from "./items/armor-sheet.js";
+import {
+    DishonoredTalentSheet
+} from "./items/talent-sheet.js";
+import {
+    DishonoredContactSheet
+} from "./items/contact-sheet.js";
+import {
+    DishonoredPowerSheet
+} from "./items/power-sheet.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -43,19 +58,34 @@ Hooks.once("init", async function() {
         types: ["character"],
         makeDefault: true
     });
-    // Actors.registerSheet("dishonored", DishonoredNPCSheet, {
-    //     types: ["npc"]
-    // });
+    Actors.registerSheet("dishonored", DishonoredNPCSheet, {
+        types: ["npc"]
+    });
     Items.unregisterSheet("core", ItemSheet);
     Items.registerSheet("dishonored", DishonoredItemSheet, {
         types: ["item"],
         makeDefault: true
     });
+    Items.registerSheet("dishonored", DishonoredFocusSheet, {
+        types: ["focus"],
+    });
+    Items.registerSheet("dishonored", DishonoredBonecharmSheet, {
+        types: ["bonecharm"],
+    });
+    Items.registerSheet("dishonored", DishonoredWeaponSheet, {
+        types: ["weapon"],
+    });
+    Items.registerSheet("dishonored", DishonoredArmorSheet, {
+        types: ["armor"],
+    });
     Items.registerSheet("dishonored", DishonoredTalentSheet, {
         types: ["talent"],
     });
-    Items.registerSheet("dishonored", DishonoredFocusSheet, {
-        types: ["focus"],
+    Items.registerSheet("dishonored", DishonoredContactSheet, {
+        types: ["contact"],
+    });
+    Items.registerSheet("dishonored", DishonoredPowerSheet, {
+        types: ["power"],
     });
 
     // Register system settings

--- a/module/items/armor-sheet.js
+++ b/module/items/armor-sheet.js
@@ -1,0 +1,49 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredArmorSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "armor"],
+            template: "systems/FVTT-Dishonored/templates/items/armor-sheet.html",
+            width: 400,
+            height: 200,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/module/items/bonecharm-sheet.js
+++ b/module/items/bonecharm-sheet.js
@@ -1,0 +1,49 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredBonecharmSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "bonecharm"],
+            template: "systems/FVTT-Dishonored/templates/items/bonecharm-sheet.html",
+            width: 400,
+            height: 200,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/module/items/contact-sheet.js
+++ b/module/items/contact-sheet.js
@@ -1,0 +1,49 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredContactSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "contact"],
+            template: "systems/FVTT-Dishonored/templates/items/contact-sheet.html",
+            width: 400,
+            height: 200,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/module/items/focus-sheet.js
+++ b/module/items/focus-sheet.js
@@ -1,0 +1,52 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredFocusSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "focus"],
+            template: "systems/FVTT-Dishonored/templates/items/focus-sheet.html",
+            width: 400,
+            height: 200,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        if (data.data.rating > 5) data.data.rating = 5;
+        if (data.data.rating < 0) data.data.rating = 0;
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/module/items/item-sheet.js
+++ b/module/items/item-sheet.js
@@ -21,9 +21,6 @@ export class DishonoredItemSheet extends ItemSheet {
     getData() {
         const data = super.getData();
         data.dtypes = ["String", "Number", "Boolean"];
-        for (let attr of Object.values(data.data.attributes)) {
-            attr.isCheckbox = attr.dtype === "Boolean";
-        }
         return data;
     }
 

--- a/module/items/power-sheet.js
+++ b/module/items/power-sheet.js
@@ -1,0 +1,49 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredPowerSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "power"],
+            template: "systems/FVTT-Dishonored/templates/items/power-sheet.html",
+            width: 400,
+            height: 200,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/module/items/talent-sheet.js
+++ b/module/items/talent-sheet.js
@@ -1,0 +1,49 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredTalentSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "talent"],
+            template: "systems/FVTT-Dishonored/templates/items/talent-sheet.html",
+            width: 500,
+            height: 250,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/module/items/weapon-sheet.js
+++ b/module/items/weapon-sheet.js
@@ -1,0 +1,49 @@
+/**
+ * Extend the basic ItemSheet with some very simple modifications
+ * @extends {ItemSheet}
+ */
+export class DishonoredWeaponSheet extends ItemSheet {
+
+    /** @override */
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ["dishonored", "sheet", "weapon"],
+            template: "systems/FVTT-Dishonored/templates/items/weapon-sheet.html",
+            width: 400,
+            height: 400,
+            tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
+        });
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    getData() {
+        const data = super.getData();
+        data.dtypes = ["String", "Number", "Boolean"];
+
+        return data;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    setPosition(options = {}) {
+        const position = super.setPosition(options);
+        const sheetBody = this.element.find(".sheet-body");
+        const bodyHeight = position.height - 192;
+        sheetBody.css("height", bodyHeight);
+        return position;
+    }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+
+        // Everything below here is only needed if the sheet is editable
+        if (!this.options.editable) return;
+
+    }
+}

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -193,8 +193,12 @@
     cursor: pointer;
 }
 
-.dishonored .notes .editor {
+.dishonored .notes {
     height: 200px;
+}
+
+.dishonored .notes .editor {
+    height: 100%;
 }
 
 .dishonored .section-title {
@@ -213,7 +217,7 @@
 }
 
 .dishonored .item-section .title {
-    width: 95%;
+    width: 100%;
     text-align: center;
 }
 
@@ -235,3 +239,64 @@
 .dishonored .advisory {
     font-weight: bold;
 }
+
+.dishonored .item-flex {
+    display: flex;
+    flex-direction: row;
+}
+
+.dishonored .item-image {
+    width: 26px;
+}
+
+.dishonored .item-name {
+    width: calc(100% - 58px);
+}
+
+.dishonored .item-controls {
+    width: 32px;
+}
+
+.dishonored .item-two-section-main {
+    width: calc(3*((100% - 58px)/4));
+}
+
+.dishonored .item-two-section-sub {
+    width: calc((100% - 58px)/4);
+}
+
+.dishonored .item-two-section {
+    width: calc((100% - 58px)/2);
+}
+
+
+.dishonored .item-img {
+   width: 50px;
+}
+
+.dishonored .item-header-input {
+   width: 50%;
+   font-weight: bold;
+   font-size: 12pt;
+}
+
+.dishonored .item-header-input-main {
+    width: 80%;
+    font-weight: bold;
+    font-size: 12pt;
+ }
+
+ .dishonored .item-header-input-sub {
+    width: 20%;
+    font-weight: bold;
+    font-size: 12pt;
+ }
+
+.dishonored .description {
+    height: calc(100% - 50px);
+}
+
+.dishonored .description .editor {
+    height: 100%;
+}
+

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -195,6 +195,7 @@
 
 .dishonored .notes {
     height: 200px;
+    text-align: left;
 }
 
 .dishonored .notes .editor {
@@ -280,7 +281,19 @@
    font-size: 12pt;
 }
 
+.dishonored .item-header-input-single {
+    width: 100%;
+    font-weight: bold;
+    font-size: 12pt;
+ }
+
 .dishonored .item-header-input-main {
+    width: 80%;
+    font-weight: bold;
+    font-size: 12pt;
+ }
+
+ .dishonored .item-header-input-mini-main {
     width: 80%;
     font-weight: bold;
     font-size: 12pt;
@@ -300,3 +313,6 @@
     height: 100%;
 }
 
+.dishonored .npc-notes {
+    text-align: center;
+}

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "FVTT-Dishonored",
     "title": "Dishonored Roleplaying Game",
     "description": "A personal rendition of the Modiphius tabletop role playing game system.",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.6.5",
     "templateVersion": 1,

--- a/template.json
+++ b/template.json
@@ -1,17 +1,86 @@
 {
     "Actor": {
         "types": ["character", "npc"],
+        "templates": {
+            "common": {
+                "notes":"",
+                "stress": {
+                    "value": 0,
+                    "max": 8
+                },
+                "truth1": "",
+                "skills": {
+                    "fight": {
+                        "label": "dishonored.actor.skill.fight",
+                        "value": 4,
+                        "selected": true
+                    },
+                    "move": {
+                        "label": "dishonored.actor.skill.move",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "study": {
+                        "label": "dishonored.actor.skill.study",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "survive": {
+                        "label": "dishonored.actor.skill.survive",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "talk": {
+                        "label": "dishonored.actor.skill.talk",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "tinker": {
+                        "label": "dishonored.actor.skill.tinker",
+                        "value": 4,
+                        "selected": false
+                    }
+                },
+                "styles": {
+                    "boldly": {
+                        "label": "dishonored.actor.style.boldly",
+                        "value": 4,
+                        "selected": true
+                    },
+                    "carefully": {
+                        "label": "dishonored.actor.style.carefully",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "cleverly": {
+                        "label": "dishonored.actor.style.cleverly",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "forcefully": {
+                        "label": "dishonored.actor.style.forcefully",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "quietly": {
+                        "label": "dishonored.actor.style.quietly",
+                        "value": 4,
+                        "selected": false
+                    },
+                    "swiftly": {
+                        "label": "dishonored.actor.style.swiftly",
+                        "value": 4,
+                        "selected": false
+                    }
+                }
+            }
+        },
         "character": {
+            "templates": ["common"],
             "age": 21,
-            "truth1": "",
             "truth2": "",
             "archetype": "",
             "outlook": "",
-            "notes":"",
-            "stress": {
-                "value": 0,
-                "max": 8
-            },
             "void": {
                 "value": 3,
                 "max": 3
@@ -19,80 +88,30 @@
             "momentum": {
                 "value": 0
             },
-            "skills": {
-                "fight": {
-                    "label": "dishonored.actor.skill.fight",
-                    "value": 4,
-                    "selected": true
-                },
-                "move": {
-                    "label": "dishonored.actor.skill.move",
-                    "value": 4,
-                    "selected": false
-                },
-                "study": {
-                    "label": "dishonored.actor.skill.study",
-                    "value": 4,
-                    "selected": false
-                },
-                "survive": {
-                    "label": "dishonored.actor.skill.survive",
-                    "value": 4,
-                    "selected": false
-                },
-                "talk": {
-                    "label": "dishonored.actor.skill.talk",
-                    "value": 4,
-                    "selected": false
-                },
-                "tinker": {
-                    "label": "dishonored.actor.skill.tinker",
-                    "value": 4,
-                    "selected": false
-                }
-            },
-            "styles": {
-                "boldly": {
-                    "label": "dishonored.actor.style.boldly",
-                    "value": 4,
-                    "selected": true
-                },
-                "carefully": {
-                    "label": "dishonored.actor.style.carefully",
-                    "value": 4,
-                    "selected": false
-                },
-                "cleverly": {
-                    "label": "dishonored.actor.style.cleverly",
-                    "value": 4,
-                    "selected": false
-                },
-                "forcefully": {
-                    "label": "dishonored.actor.style.forcefully",
-                    "value": 4,
-                    "selected": false
-                },
-                "quietly": {
-                    "label": "dishonored.actor.style.quietly",
-                    "value": 4,
-                    "selected": false
-                },
-                "swiftly": {
-                    "label": "dishonored.actor.style.swiftly",
-                    "value": 4,
-                    "selected": false
-                }
-            },
+            
             "attributes": {}
         }
     },
     "Item": {
         "types": ["item", "rune", "focus", "bonecharm", "weapon", "armor", "talent", "contact", "power"],
+        "templates": {
+            "common": {
+                "description": ""
+            }
+        },
         "item": {
-            "description": "",
+            "templates": ["common"],
             "quantity": 1,
             "weight": 0,
             "attributes": {}
+        },
+        "talent": {
+            "templates": ["common"],
+            "type": ""
+        },
+        "focus": {
+            "templates": ["common"],
+            "rating": 0
         }
     }
 }

--- a/template.json
+++ b/template.json
@@ -87,13 +87,14 @@
             },
             "momentum": {
                 "value": 0
-            },
-            
-            "attributes": {}
+            }
+        },
+        "npc": {
+            "templates": ["common"]
         }
     },
     "Item": {
-        "types": ["item", "rune", "focus", "bonecharm", "weapon", "armor", "talent", "contact", "power"],
+        "types": ["item", "focus", "bonecharm", "weapon", "armor", "talent", "contact", "power"],
         "templates": {
             "common": {
                 "description": ""
@@ -101,17 +102,57 @@
         },
         "item": {
             "templates": ["common"],
-            "quantity": 1,
-            "weight": 0,
-            "attributes": {}
+            "cost": 0,
+            "quantity": 1
+        },
+        "focus": {
+            "templates": ["common"],
+            "rating": 0
+        },
+        "bonecharm": {
+            "templates": ["common"]
+        },
+        "weapon": {
+            "templates": ["common"],
+            "damage": 0,
+            "cost": 0,
+            "qualities": {
+                "armorpierce": false,
+                "awkward": false,
+                "blast": false,
+                "block": false,
+                "burn": false,
+                "concealed": false,
+                "melee": false,
+                "messy": false,
+                "mine": false,
+                "rangeddistant": false,
+                "rangednearby": false
+            }
+        },
+        "armor": {
+            "templates": ["common"],
+            "protection": 0,
+            "cost": 0
         },
         "talent": {
             "templates": ["common"],
             "type": ""
         },
-        "focus": {
+        "contact": {
             "templates": ["common"],
-            "rating": 0
+            "relationship": {
+                "great": false,
+                "fair": false,
+                "neutral": false,
+                "poor": false,
+                "dire": false
+            }
+        },
+        "power": {
+            "templates": ["common"],
+            "manacost": 0,
+            "runecost": 0
         }
     }
 }

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -145,7 +145,7 @@
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "contact")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
                             <h4 class="item-name">{{item.name}}</h4>
                             <div class="item-controls">
@@ -178,7 +178,7 @@
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "talent")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
                             <h4 class="item-name">{{item.name}}</h4>
                             <div class="item-controls">
@@ -197,14 +197,18 @@
                             <a class="item-control item-create add-item" title="Create item" data-type="focus"><i class="fas fa-plus"></i></a>
                         </div>
                         <div class="stat-flex-row">
-                            <div class="stat-text advisory">{{localize 'dishonored.actor.focus.name'}}</div>
-                            <div class="stat-field advisory">{{localize 'dishonored.actor.focus.value'}}</div>
+                            <div class="item-image"></div>
+                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.focus.name'}}</div>
+                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.focus.value'}}</div>
+                            <div class="item-controls"></div>
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "focus")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
-                            <h4 class="item-name">{{item.name}}</h4>
+                            <h4 class="item-two-section-main">{{item.name}}</h4>
+                            <!-- <input name="item.data.rating" value="{{item.data.rating}}" data-dtype="Number" /> -->
+                            <h4 class="item-two-section-sub">{{item.data.rating}}</h4>
                             <div class="item-controls">
                                 <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                                 <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
@@ -232,6 +236,18 @@
                             <div class="title">{{localize 'dishonored.actor.power.title'}}</div>
                             <a class="item-control item-create add-item" title="Create item" data-type="power"><i class="fas fa-plus"></i></a>
                         </div>
+                        {{#each actor.items as |item type id|}}
+                        {{#if (eq item.type "power")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-name">{{item.name}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
                     </div>
                 </div>
                 <div class="column">
@@ -245,7 +261,7 @@
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "weapon")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
                             <h4 class="item-name">{{item.name}}</h4>
                             <div class="item-controls">
@@ -261,7 +277,7 @@
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "armor")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
                             <h4 class="item-name">{{item.name}}</h4>
                             <div class="item-controls">
@@ -277,7 +293,7 @@
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "bonecharm")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
                             <h4 class="item-name">{{item.name}}</h4>
                             <div class="item-controls">
@@ -293,7 +309,7 @@
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "item")}}
-                        <li class="item flexrow" data-item-id="{{item._id}}">
+                        <li class="item item-flex" data-item-id="{{item._id}}">
                             <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
                             <h4 class="item-name">{{item.name}}</h4>
                             <div class="item-controls">

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -1,0 +1,224 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="main-content">
+        <div class="header-fields">
+            <div class="row">
+                <div class="column headings">
+                    {{localize 'dishonored.actor.character.name'}}
+                </div>
+                <div class="column headings">
+                    <div> {{localize 'dishonored.actor.character.firstTruth'}} </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="column headings">
+                    <input name="name" type="text" value="{{actor.name}}" placeholder="Name" />
+                </div>
+                <div class="column">
+                    <input name="data.truth1" type="text" value="{{data.truth1}}" />
+                </div>
+            </div>
+        </div>
+        <div class="separator"></div>
+        <div class="main">
+            <div class="row">
+                <div class="column">
+                    <div class="skill-section">
+                        <div class="skill-title section-title">
+                            {{localize 'dishonored.actor.skill.title'}}
+                        </div>
+                        <div class="stat-flex-row">
+                            <div class="advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
+                            <div class="stat-text advisory">{{localize 'dishonored.actor.skill.name'}}</div>
+                            <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
+                        </div>
+                        {{#each data.skills as |skill key|}}
+                        <div class="stat-flex-row">
+                            <input class="skill-roll-selector" id="{{key}}.selector" type="checkbox" name="data.skills.{{key}}.selected" data-dtype="Boolean" {{checked skill.selected}}>
+                            <div class="stat-text"> {{localize skill.label}} </div>
+                            <input class="stat-field" id="{{key}}" name="data.skills.{{key}}.value" type="text" value="{{skill.value}}" />
+                        </div>
+                        {{/each}}
+                    </div>
+                </div>
+                <div class="column">
+                    <div class="stress-section">
+                        <div class="stress-title headings">
+                            {{localize 'dishonored.actor.character.stress'}}
+                        </div>
+                        <div class="mainflex">
+                            <input type="hidden" id="total-stress" name="data.stress.value" value="{{data.stress.value}}" data-dtype="Number" />
+                            <div class="stressbox" id="stress-1">1</div>
+                            <div class="stressbox" id="stress-2">2</div>
+                            <div class="stressbox" id="stress-3">3</div>
+                            <div class="stressbox" id="stress-4">4</div>
+                            <div class="stressbox" id="stress-5">5</div>
+                            <div class="stressbox" id="stress-6">6</div>
+                            <div class="stressbox" id="stress-7">7</div>
+                            <div class="stressbox" id="stress-8">8</div>
+                            <div class="stressbox" id="stress-9">9</div>
+                            <div class="stressbox" id="stress-10">10</div>
+                            <div class="stressbox" id="stress-11">11</div>
+                            <div class="stressbox" id="stress-12">12</div>
+                        </div>
+                    </div>
+                    <div class="separator"></div>
+                    <div class="img-section">
+                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
+                    </div>
+                    <div class="separator"></div>
+                    <div class="check-section">
+                        <div class="check-button">{{localize 'dishonored.actor.skisty.check'}}</div>
+                    </div>
+                </div>
+                <div class="column">
+                    <div class="style-section">
+                        <div class="style-title section-title">
+                            {{localize 'dishonored.actor.style.title'}}
+                        </div>
+                        <div class="stat-flex-row">
+                            <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
+                            <div class="stat-text advisory">{{localize 'dishonored.actor.style.name'}}</div>
+                            <div class="advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
+                        </div>
+                        {{#each data.styles as |style key|}}
+                        <div class="stat-flex-row">
+                            <input class="stat-field" id="{{key}}" name="data.styles.{{key}}.value" type="text" value="{{style.value}}" placeholder="Name" />
+                            <div class="stat-text"> {{localize style.label}} </div>
+                            <input class="style-roll-selector" id="{{key}}.selector" type="checkbox" name="data.styles.{{key}}.selected" data-dtype="Boolean" {{checked style.selected}}>
+                        </div>
+                        {{/each}}
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="column">
+                    <div class="focus-section">
+                        <div class="focus-title section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.focus.title'}}</div>
+                            <a class="item-control item-create add-item" title="Create item" data-type="focus"><i class="fas fa-plus"></i></a>
+                        </div>
+                        <div class="stat-flex-row">
+                            <div class="item-image"></div>
+                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.focus.name'}}</div>
+                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.focus.value'}}</div>
+                            <div class="item-controls"></div>
+                        </div>
+                        {{#each actor.items as |item id|}}
+                        {{#if (eq item.type "focus")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-two-section-main">{{item.name}}</h4>
+                            <!-- <input name="item.data.rating" value="{{item.data.rating}}" data-dtype="Number" /> -->
+                            <h4 class="item-two-section-sub">{{item.data.rating}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
+                    </div>
+                </div>
+                <div class="column">
+                    <div class="power-section">
+                        <div class="power-title section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.power.title'}}</div>
+                            <a class="item-control item-create add-item" title="Create item" data-type="power"><i class="fas fa-plus"></i></a>
+                        </div>
+                        {{#each actor.items as |item type id|}}
+                        {{#if (eq item.type "power")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-name">{{item.name}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
+                    </div>
+                </div>
+                <div class="column">
+                    <div class="belonging-section">
+                        <div class="belonging-title section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.belonging.title'}}</div>
+                        </div>
+                        <div class="sub-section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.belonging.weapon.title'}}</div>
+                            <a class="item-control item-create add-item-sub" title="Create item" data-type="weapon"><i class="fas fa-plus"></i></a>
+                        </div>
+                        {{#each actor.items as |item type id|}}
+                        {{#if (eq item.type "weapon")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-name">{{item.name}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
+                        <div class="sub-section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.belonging.armor.title'}}</div>
+                            <a class="item-control item-create add-item-sub" title="Create item" data-type="armor"><i class="fas fa-plus"></i></a>
+                        </div>
+                        {{#each actor.items as |item type id|}}
+                        {{#if (eq item.type "armor")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-name">{{item.name}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
+                        <div class="sub-section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
+                            <a class="item-control item-create add-item-sub" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
+                        </div>
+                        {{#each actor.items as |item type id|}}
+                        {{#if (eq item.type "bonecharm")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-name">{{item.name}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
+                        <div class="sub-section-title item-section">
+                            <div class="title">{{localize 'dishonored.actor.belonging.other.title'}}</div>
+                            <a class="item-control item-create add-item-sub" title="Create item" data-type="item"><i class="fas fa-plus"></i></a>
+                        </div>
+                        {{#each actor.items as |item type id|}}
+                        {{#if (eq item.type "item")}}
+                        <li class="item item-flex" data-item-id="{{item._id}}">
+                            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+                            <h4 class="item-name">{{item.name}}</h4>
+                            <div class="item-controls">
+                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                            </div>
+                        </li>
+                        {{/if}}
+                        {{/each}}
+                    </div>
+                </div>
+            </div>
+            <div class="note-section">
+                <div class="note-title section-title npc-notes">
+                    {{localize 'dishonored.actor.note.title'}}
+                </div>
+                <div class="notes">
+                    {{editor content=data.notes target="data.notes" button=true owner=owner editable=editable}}
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/templates/items/armor-sheet.html
+++ b/templates/items/armor-sheet.html
@@ -7,12 +7,12 @@
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
             <div class="item-header-input-sub">
-                <label>Quantity</label>
-                <input type="text" name="data.rating" value="{{data.quantity}}" data-dtype="Number" />
+                <label>Protection</label>
+                <input type="text" name="data.protection" value="{{data.protection}}" data-dtype="Number" />
             </div>
             <div class="item-header-input-sub">
                 <label>Value</label>
-                <input type="text" name="data.rating" value="{{data.cost}}" data-dtype="Number" />
+                <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
             </div>
         </div>
     </div>

--- a/templates/items/bonecharm-sheet.html
+++ b/templates/items/bonecharm-sheet.html
@@ -2,17 +2,9 @@
     <div class="header-fields">
         <div class="row">
             <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-mini-main">
+            <div class="item-header-input-single">
                 <label>Name</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
-            </div>
-            <div class="item-header-input-sub">
-                <label>Quantity</label>
-                <input type="text" name="data.rating" value="{{data.quantity}}" data-dtype="Number" />
-            </div>
-            <div class="item-header-input-sub">
-                <label>Value</label>
-                <input type="text" name="data.rating" value="{{data.cost}}" data-dtype="Number" />
             </div>
         </div>
     </div>

--- a/templates/items/contact-sheet.html
+++ b/templates/items/contact-sheet.html
@@ -2,17 +2,13 @@
     <div class="header-fields">
         <div class="row">
             <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-mini-main">
+            <div class="item-header-input-main">
                 <label>Name</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
             <div class="item-header-input-sub">
-                <label>Quantity</label>
-                <input type="text" name="data.rating" value="{{data.quantity}}" data-dtype="Number" />
-            </div>
-            <div class="item-header-input-sub">
-                <label>Value</label>
-                <input type="text" name="data.rating" value="{{data.cost}}" data-dtype="Number" />
+                <label>Relation</label>
+                <!-- <input type="text" name="data.rating" value="{{data.rating}}" data-dtype="Number" /> -->
             </div>
         </div>
     </div>

--- a/templates/items/focus-sheet.html
+++ b/templates/items/focus-sheet.html
@@ -1,0 +1,18 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="header-fields">
+        <div class="row">
+            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="item-header-input-main">
+                <label>Name</label>
+                <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
+            </div>
+            <div class="item-header-input-sub">
+                <label>Rating</label>
+                <input type="text" name="data.rating" value="{{data.rating}}" data-dtype="Number" />
+            </div>
+        </div>
+    </div>
+        <div class="description">
+            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+        </div>
+</form>

--- a/templates/items/power-sheet.html
+++ b/templates/items/power-sheet.html
@@ -7,12 +7,12 @@
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
             <div class="item-header-input-sub">
-                <label>Quantity</label>
-                <input type="text" name="data.rating" value="{{data.quantity}}" data-dtype="Number" />
+                <label>Mana</label>
+                <input type="text" name="data.manacost" value="{{data.manacost}}" data-dtype="Number" />
             </div>
             <div class="item-header-input-sub">
-                <label>Value</label>
-                <input type="text" name="data.rating" value="{{data.cost}}" data-dtype="Number" />
+                <label>Rune</label>
+                <input type="text" name="data.runecost" value="{{data.runecost}}" data-dtype="Number" />
             </div>
         </div>
     </div>

--- a/templates/items/talent-sheet.html
+++ b/templates/items/talent-sheet.html
@@ -1,0 +1,18 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="header-fields">
+        <div class="row">
+            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="item-header-input">
+                <label>Name</label>
+                <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
+            </div>
+            <div class="item-header-input">
+                <label>Type</label>
+                <input type="text" name="data.type" value="{{data.type}}" />
+            </div>
+        </div>
+    </div>
+        <div class="description">
+            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+        </div>
+</form>

--- a/templates/items/weapon-sheet.html
+++ b/templates/items/weapon-sheet.html
@@ -7,12 +7,12 @@
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
             <div class="item-header-input-sub">
-                <label>Quantity</label>
-                <input type="text" name="data.rating" value="{{data.quantity}}" data-dtype="Number" />
+                <label>Damage</label>
+                <input type="text" name="data.damage" value="{{data.damage}}" data-dtype="Number" />
             </div>
             <div class="item-header-input-sub">
                 <label>Value</label>
-                <input type="text" name="data.rating" value="{{data.cost}}" data-dtype="Number" />
+                <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fairly chunky, but will look small on the release notes:

- Added to templates to template.json.
- All item and actor types now have a populated template.json entry. This includes a common template amongst them.
- All item and actor types now have js files and HTML sheets to go alongside them. The sheets are still a work in progress but are somewhat usable for its general purpose. These are also not currently "rollable" as such they don't prove any direct purpose in Foundry as of the moment.
- Provided an NPC sheet, a basic implementation for now, but actually is quite practical for its usage.
- Amended window sizes to better fit the character sheets.
- Removed attributes from the template. This wasn't needed and as such just clogged up various js files.
- Improved item visibility on the character sheet.