### PR TITLE
0.2.2 Dice Too Nice

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -101,6 +101,7 @@
     "dishonored.roll.power.rune": "<b>|#|</b> Runes",
     "dishonored.roll.power.mana": "Costs <b>|#|</b> Mana to use",
     "dishonored.roll.item.value": "|#| Coins",
+    "dishonored.roll.item.quantity": "|#|x Items",
 
 
 

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -1,15 +1,14 @@
-/**
- * Extend the base Actor entity by defining a custom roll data structure which is ideal for the Simple system.
- * @extends {Actor}
- */
+import {
+    DishonoredRollDialog
+} from '../apps/roll-dialog.js'
+import {
+    DishonoredRoll
+} from '../roll.js'
+
 export class DishonoredActor extends Actor {
 	prepareData() {
 		super.prepareData();
-
 		const actorData = this.data;
-		const data = actorData.data;
-		const flags = actorData.flags;
-
 		if (actorData.type === 'character') this._prepareCharacterData(actorData);
 	}
 
@@ -17,4 +16,110 @@ export class DishonoredActor extends Actor {
 		const data = actorData.data;
 		// console.log(data);
 	}
+}
+
+export class DishonoredSharedActorFunctions {
+
+	// This function renders all the tracks. This will be used every time the character sheet is loaded. It is a vital element as such it runs before most other code!
+	dishonoredRenderTracks(html, stressTrackMax, voidPointsMax, expPointsMax, momentumMax) {
+		var i;
+		if (stressTrackMax) {
+			for (i = 0; i < stressTrackMax; i++) {
+				if (i + 1 <= html.find('#total-stress')[0].value) {
+					html.find('[id^="stress"]')[i].setAttribute("data-selected", "true");
+					html.find('[id^="stress"]')[i].style.backgroundColor = "#191813";
+					html.find('[id^="stress"]')[i].style.color = "#ffffff";
+				} else {
+					html.find('[id^="stress"]')[i].removeAttribute("data-selected");
+					html.find('[id^="stress"]')[i].style.backgroundColor = "rgb(255, 255, 255, 0.3)";
+					html.find('[id^="stress"]')[i].style.color = "";
+				}
+			}
+		}
+		if (voidPointsMax) {
+			for (i = 0; i < voidPointsMax; i++) {
+				if (i + 1 <= html.find('#total-void')[0].value) {
+					html.find('[id^="void"]')[i].setAttribute("data-selected", "true");
+					html.find('[id^="void"]')[i].style.backgroundColor = "#191813";
+					html.find('[id^="void"]')[i].style.color = "#ffffff";
+				} else {
+					html.find('[id^="void"]')[i].removeAttribute("data-selected");
+					html.find('[id^="void"]')[i].style.backgroundColor = "rgb(255, 255, 255, 0.3)";
+					html.find('[id^="void"]')[i].style.color = "";
+				}
+			}
+		}
+		if (expPointsMax) {
+			for (i = 0; i < expPointsMax; i++) {
+				if (i + 1 <= html.find('#total-exp')[0].value) {
+					html.find('[id^="exp"]')[i].setAttribute("data-selected", "true");
+					html.find('[id^="exp"]')[i].style.backgroundColor = "#191813";
+					html.find('[id^="exp"]')[i].style.color = "#ffffff";
+				} else {
+					html.find('[id^="exp"]')[i].removeAttribute("data-selected");
+					html.find('[id^="exp"]')[i].style.backgroundColor = "rgb(255, 255, 255, 0.3)";
+					html.find('[id^="exp"]')[i].style.color = "";
+				}
+			}
+		}
+		if(momentumMax) {
+			for (i = 0; i < 6; i++) {
+				if (i + 1 <= html.find('#total-mom')[0].value) {
+					html.find('[id^="mom"]')[i].setAttribute("data-selected", "true");
+					html.find('[id^="mom"]')[i].style.backgroundColor = "#191813";
+					html.find('[id^="mom"]')[i].style.color = "#ffffff";
+				} else {
+					html.find('[id^="mom"]')[i].removeAttribute("data-selected");
+					html.find('[id^="mom"]')[i].style.backgroundColor = "rgb(255, 255, 255, 0.3)";
+					html.find('[id^="mom"]')[i].style.color = "";
+				}
+			}
+		}
+	}
+
+    // This handles performing a skill test using the "Perform Check" button.
+    async rollSkillTest(event, checkTarget, selectedSkill, selectedStyle, speaker) {
+        event.preventDefault();
+        let rolldialog = await DishonoredRollDialog.create();
+        if (rolldialog) {
+            let dicePool = rolldialog.get("dicePoolSlider");
+            let focusTarget = parseInt(rolldialog.get("dicePoolFocus"));
+            let dishonoredRoll = new DishonoredRoll();
+            dishonoredRoll.performSkillTest(dicePool, checkTarget, focusTarget, selectedSkill, selectedStyle, speaker);
+        }
+    }
+
+    // This handles performing an "item" roll by clicking the item's image.
+    async rollGenericItem(event, type, id, speaker) {
+        event.preventDefault();
+        var item = speaker.items.get(id);
+        let dishonoredRoll = new DishonoredRoll();
+        // It will send it to a different method depending what item type was sent to it.
+        switch(type) {
+            case "item":
+                dishonoredRoll.performItemRoll(item, speaker);
+                break;
+            case "focus":
+                dishonoredRoll.performFocusRoll(item, speaker);
+                break;
+            case "bonecharm":
+                dishonoredRoll.performBonecharmRoll(item, speaker);
+                break;
+            case "weapon":
+                dishonoredRoll.performWeaponRoll(item, speaker);
+                break;
+            case "armor":
+                dishonoredRoll.performArmorRoll(item, speaker);
+                break;
+            case "talent":
+                dishonoredRoll.performTalentRoll(item, speaker);
+                break;
+            case "contact":
+                dishonoredRoll.performContactRoll(item, speaker);
+                break;
+            case "power":
+                dishonoredRoll.performPowerRoll(item, speaker);
+                break;
+        }
+    }
 }

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -8,13 +8,7 @@ import {
 export class DishonoredActor extends Actor {
 	prepareData() {
 		super.prepareData();
-		const actorData = this.data;
-		if (actorData.type === 'character') this._prepareCharacterData(actorData);
-	}
-
-	_prepareCharacterData(actorData) {
-		const data = actorData.data;
-		// console.log(data);
+		// const actorData = this.data;
 	}
 }
 
@@ -23,6 +17,7 @@ export class DishonoredSharedActorFunctions {
 	// This function renders all the tracks. This will be used every time the character sheet is loaded. It is a vital element as such it runs before most other code!
 	dishonoredRenderTracks(html, stressTrackMax, voidPointsMax, expPointsMax, momentumMax) {
 		var i;
+		// Checks if details for the Stress Track was included, this should happen in all cases!
 		if (stressTrackMax) {
 			for (i = 0; i < stressTrackMax; i++) {
 				if (i + 1 <= html.find('#total-stress')[0].value) {
@@ -36,6 +31,7 @@ export class DishonoredSharedActorFunctions {
 				}
 			}
 		}
+		// Checks if details for the Void Track was included, this should happen for all Characters!
 		if (voidPointsMax) {
 			for (i = 0; i < voidPointsMax; i++) {
 				if (i + 1 <= html.find('#total-void')[0].value) {
@@ -49,6 +45,7 @@ export class DishonoredSharedActorFunctions {
 				}
 			}
 		}
+		// Checks if details for the Experience Track was included, this should happen for all Characters!
 		if (expPointsMax) {
 			for (i = 0; i < expPointsMax; i++) {
 				if (i + 1 <= html.find('#total-exp')[0].value) {
@@ -62,6 +59,7 @@ export class DishonoredSharedActorFunctions {
 				}
 			}
 		}
+		// Checks if details for the Momentum Track was included, this should happen for all Characters!
 		if(momentumMax) {
 			for (i = 0; i < 6; i++) {
 				if (i + 1 <= html.find('#total-mom')[0].value) {
@@ -79,11 +77,13 @@ export class DishonoredSharedActorFunctions {
 
     // This handles performing a skill test using the "Perform Check" button.
     async rollSkillTest(event, checkTarget, selectedSkill, selectedStyle, speaker) {
-        event.preventDefault();
+		event.preventDefault();
+		// This creates a dialog to gather details regarding the roll and waits for a response
         let rolldialog = await DishonoredRollDialog.create();
         if (rolldialog) {
             let dicePool = rolldialog.get("dicePoolSlider");
-            let focusTarget = parseInt(rolldialog.get("dicePoolFocus"));
+			let focusTarget = parseInt(rolldialog.get("dicePoolFocus"));
+			// Once the response has been collected it then sends it to be rolled.
             let dishonoredRoll = new DishonoredRoll();
             dishonoredRoll.performSkillTest(dicePool, checkTarget, focusTarget, selectedSkill, selectedStyle, speaker);
         }

--- a/module/apps/roll-dialog.js
+++ b/module/apps/roll-dialog.js
@@ -1,9 +1,12 @@
 export class DishonoredRollDialog {
 
     static async create() {
+        // Grab the RollDialog HTML file/
         const html = await renderTemplate("systems/FVTT-Dishonored/templates/apps/dicepool.html");
+        // Create a new promise for the HTML above.
         return new Promise((resolve) => {
             let formData = null;
+            // Create a new dialog.
             const dlg = new Dialog({
                 title: game.i18n.localize('dishonored.apps.dicepoolwindow'),
                 content: html,
@@ -19,6 +22,7 @@ export class DishonoredRollDialog {
                 default: "roll",
                 close: () => {}
             });
+            // Render the dialog
             dlg.render(true);
         });
     }

--- a/module/dishonored.js
+++ b/module/dishonored.js
@@ -90,11 +90,27 @@ Hooks.once("init", async function() {
 
     // Register system settings
     game.settings.register("FVTT-Dishonored", "multipleComplications", {
-        name: 'Allow Multiple Complications?',
+        name: 'Multiple Complications:',
         hint: 'The rulebook states "Any die which rolled 20 causes a complication". This is slightly unclear and as of Version 8 of the PDF, this is still not clear - likely due to the incredible rarity. Enabling this will allow roles to display "There were x Complications" if multiple 20s are rolled. Disabling will just state a single complication.',
         scope: "world",
         type: Boolean,
         default: true,
         config: true
+    });
+
+    game.settings.register("FVTT-Dishonored", "send2ActorPermissionLevel", {
+        name: 'Send2Actor User Role:',
+        hint: 'The contact item type has the ability to create an NPC, who should be allowed to see & use this functionality?',
+        scope: "world",
+        type: String,
+        default: "ASSISTANT",
+        config: true,
+        choices: {
+          "NONE": "Switch Off Send2Actor",
+          "PLAYER": "Players",
+          "TRUSTED": "Trusted Players",
+          "ASSISTANT": "Assistant Gamemaster",
+          "GAMEMASTER": "Gamemasters",
+        }
     });
 });

--- a/module/dishonored.js
+++ b/module/dishonored.js
@@ -38,12 +38,33 @@ import {
 /* -------------------------------------------- */
 
 Hooks.once("init", async function() {
+    // Splash Screen
     console.log(`Initializing Dishonored Tabletop Roleplaying Game System`);
+    console.log('                                                        @@')
+    console.log('         @                                            @@')
+    console.log('@         @@                     @      @@         @@@@')
+    console.log('  @@       @@@                 @@@   @@@        @@@@')
+    console.log('    @@@@     @@@@@@@@@@@@@@@@@@@@    @@      @@@@@')
+    console.log('      @@@@    @@@@            @@   @@@     @@@@@')
+    console.log('        @@@@@   @     @@@@@@@@   @@@    @@@@@      @@')
+    console.log('  @@@      @@@@ @@@@@@@       @@@@@  @@@@@@    @@@@')
+    console.log('      @@@@    @@@@              @ @@@@@@   @@@@@')
+    console.log('          @@@@   @              @@@@@@  @@@  @@@')
+    console.log('                    @@@@@@@@@@@@@@@@          @@@')
+    console.log('                  @@@@        @@@@            @@@')
+    console.log('                  @@    @@@@@   @@@  @@@@@     @@')
+    console.log('                        @@@@   @@@   @@@@@     @@')
+    console.log('                    @@@       @@@@            @@@')
+    console.log('        @@@@  @  @@@@@@@@@@@@@@               @@')
+    console.log('        @@ @@  @@@@@                         @@@')
+    console.log('             @@@@                    @@    @@@')
+    console.log('            @@                         @@@@@@')
+    console.log('          @                              @@@@')
+    console.log('                                            @@@')
+    console.log('                                               @@@')
+    console.log('                                                  @@')
 
-    /**
-     * Set an initiative formula for the system
-     * @type {String}
-     */
+    // Define initiative for the system.
     CONFIG.Combat.initiative = {
         formula: "@styles.swiftly.value",
         decimals: 0
@@ -112,5 +133,14 @@ Hooks.once("init", async function() {
           "ASSISTANT": "Assistant Gamemaster",
           "GAMEMASTER": "Gamemasters",
         }
+    });
+
+    game.settings.register("FVTT-Dishonored", "maxNumberOfExperience", {
+        name: 'Maximum amount of Experience:',
+        hint: 'Max number of experience that can be given to a character. 30 is default, anything past 50 becomes almost unreadable.',
+        scope: "world",
+        type: Number,
+        default: 30,
+        config: true
     });
 });

--- a/module/items/contact-sheet.js
+++ b/module/items/contact-sheet.js
@@ -58,8 +58,7 @@ export class DishonoredContactSheet extends ItemSheet {
                 var name = $("[data-appid="+appId+"]").find('#name')[0].value;
                 var description = $("[data-appid="+appId+"]").find('.editor-content')[0].innerHTML;
                 var img = $("[data-appid="+appId+"]").find('.item-img')[0].getAttribute("src");
-                this.send2Actor(name, description, img);
-                ui.notifications.info("NPC with the name: '"+name+"' has been created!");
+                this.send2Actor(name, description, img).then(created => ui.notifications.info("NPC with the name: '"+name+"' has been created!"));
             });
         }
     }

--- a/module/items/contact-sheet.js
+++ b/module/items/contact-sheet.js
@@ -46,19 +46,22 @@ export class DishonoredContactSheet extends ItemSheet {
 
         // Everything below here is only needed if the sheet is editable
         if (!this.options.editable) {
-            for (i = 0; i < html.find('.send2actor-button').length; i++) {
-                html.find('.send2actor-button')[i].style.display = 'none';
-            }
+            html.find('.send2actor-button')[0].style.display = 'none';
             return;
         }
 
-        html.find('.send2actor-button').click(ev => {
-            var name = $("[data-appid="+appId+"]").find('#name')[0].value;
-            var description = $("[data-appid="+appId+"]").find('.editor-content')[0].innerHTML;
-            var img = $("[data-appid="+appId+"]").find('.item-img')[0].getAttribute("src");
-            this.send2Actor(name, description, img);
-        });
-
+        if (!game.user.hasRole(game.settings.get("FVTT-Dishonored", "send2ActorPermissionLevel"))) {
+            html.find('.send2actor-button')[0].style.display = 'none';
+        }
+        else {
+            html.find('.send2actor-button').click(ev => {
+                var name = $("[data-appid="+appId+"]").find('#name')[0].value;
+                var description = $("[data-appid="+appId+"]").find('.editor-content')[0].innerHTML;
+                var img = $("[data-appid="+appId+"]").find('.item-img')[0].getAttribute("src");
+                this.send2Actor(name, description, img);
+                ui.notifications.info("NPC with the name: '"+name+"' has been created!");
+            });
+        }
     }
 
     async send2Actor(name, description, img) {

--- a/module/items/focus-sheet.js
+++ b/module/items/focus-sheet.js
@@ -23,7 +23,7 @@ export class DishonoredFocusSheet extends ItemSheet {
         data.dtypes = ["String", "Number", "Boolean"];
 
         if (data.data.rating > 5) data.data.rating = 5;
-        if (data.data.rating < 0) data.data.rating = 0;
+        if (data.data.rating < 2) data.data.rating = 2;
 
         return data;
     }

--- a/module/roll.js
+++ b/module/roll.js
@@ -3,9 +3,10 @@ export class DishonoredRoll {
     async performSkillTest(dicePool, checkTarget, focusTarget, selectedSkill, selectedStyle, speaker) {
         let i;
         let result = [];
-        for (i = 1; i <= dicePool; i++) {
-            let r = new Roll("d20");
-            result.push(r.roll()._result);
+        let r = new Roll(dicePool+"d20")
+        r.roll();
+        for (i = 0; i < dicePool; i++) {
+            result.push(r.dice[0].rolls[i].roll);
         }
         let numberOfRegularSuccess = result.filter(x => x <= checkTarget && x > focusTarget).length;
         let numberOfComplications = result.filter(x => x == 20).length;
@@ -66,17 +67,38 @@ export class DishonoredRoll {
             `<h4 class="dice-total">` + actualSuccessText + `</h4>
 				</div>
 			</div>
-		`
-        ChatMessage.create({
-            user: game.user._id,
-            isRoll: true,
-            speaker: ChatMessage.getSpeaker({ actor: speaker }),
-            flavor: flavor,
-            content: html,
-            sound: "sounds/dice.wav"
-        }).then(msg => {
-            return msg
-        });
+        `
+
+        if(game.dice3d) {
+            game.dice3d.showForRoll(r).then(displayed => {
+                ChatMessage.create({
+                    user: game.user._id,
+                    isRoll: true,
+                    roll: r,
+                    speaker: ChatMessage.getSpeaker({ actor: speaker }),
+                    flavor: flavor,
+                    content: html,
+                    sound: "sounds/dice.wav"
+                }).then(msg => {
+                    console.log(msg);
+                    return msg
+                });
+            });
+        }
+        else {
+            ChatMessage.create({
+                user: game.user._id,
+                isRoll: true,
+                roll: r,
+                speaker: ChatMessage.getSpeaker({ actor: speaker }),
+                flavor: flavor,
+                content: html,
+                sound: "sounds/dice.wav"
+            }).then(msg => {
+                console.log(msg);
+                return msg
+            });
+        };
     }
 
     async performItemRoll(item, speaker) {

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -62,6 +62,10 @@
     flex-direction: row;
 }
 
+.dishonored .mombar {
+    width: 100%;
+}
+
 .dishonored .mombox {
     width: calc(100%/6);
     height: 14px;

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "FVTT-Dishonored",
     "title": "Dishonored Roleplaying Game Unofficial",
     "description": "An unofficial rendition of the Modiphius tabletop role playing game system.",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.7.0",
     "templateVersion": 1,

--- a/template.json
+++ b/template.json
@@ -115,7 +115,7 @@
         },
         "focus": {
             "templates": ["common"],
-            "rating": 0
+            "rating": 2
         },
         "bonecharm": {
             "templates": ["common"]

--- a/template.json
+++ b/template.json
@@ -8,10 +8,6 @@
                     "value": 0,
                     "max": 4
                 },
-                "mana": {
-                    "value": 0,
-                    "max": 6
-                },
                 "truth1": "",
                 "skills": {
                     "fight": {
@@ -83,6 +79,10 @@
             "experience": 0,
             "templates": ["common"],
             "age": 21,
+            "mana": {
+                "value": 0,
+                "max": 6
+            },
             "truth2": "",
             "archetype": "",
             "outlook": "",

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -110,12 +110,7 @@
                 </div>
                 <div class="momentum-track">
                     <input type="hidden" id="total-mom" name="data.momentum.value" value="{{data.momentum.value}}" data-dtype="Number" />
-                    <div class="mombox" id="mom-1">1</div>
-                    <div class="mombox" id="mom-2">2</div>
-                    <div class="mombox" id="mom-3">3</div>
-                    <div class="mombox" id="mom-4">4</div>
-                    <div class="mombox" id="mom-5">5</div>
-                    <div class="mombox" id="mom-6">6</div>
+                    <div id="bar-mom-renderer" class="mainflex mombar"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
A chunky update behind the scenes, but very little in functionality has been added.
### Key Features:
- Added Support for Dice So Nice (fixes #60 - thanks Kruvek!)
- Amended the Send2Actor functionality, previously it was available to all. Now you can change who sees this in the system settings. (fixes #41)
- Changed focuses to now only range between 2-5, as everyone has a focus of 1 and you can't get a focus of 0! (fixes #57 - thanks again Kruvek for reminding me to raise this one!). **NOTE**: any Focuses built before this update won't update until you open them.
- Quantity now shows on items when posting as a roll.

### Other Fixes:
- Mana has been moved to characters only due to the dependency that it's calculated via void points. Also, there was a bug with mana that meant 10 < 2. Ensured that it is parsed as an int for that calculation. (fixes #61)
- Improved the handling of identical code between the actor sheets (they now reference a new class in the Actor.js and both NPC and Character share the same code in that class).
- Optimised the code in the Character and NPC sheets. Updating the sheets should be a little bit faster!
- Optimised rolling code significantly. This should be slightly faster, but most importantly is **ALOT** cleaner.
- Started to comment on the JavaScript files (around two-thirds are done - see #53 for exact details. NOTE: the actors have much more js code to go through). The optimisation of the code is because of this.