### PR TITLE
0.2.3 Un-exceeding Limitations

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -17,7 +17,7 @@
     "dishonored.actor.character.archetype": "Archetype",
     "dishonored.actor.character.outlook": "Outlook",
     "dishonored.actor.character.void": "Void Points Track",
-    "dishonored.actor.skisty.select": "Selected",
+    "dishonored.actor.skisty.select": "Select",
     "dishonored.actor.skisty.mod": "Modifier",
     "dishonored.actor.skisty.check": "Perform Check",
     "dishonored.actor.skill.title": "Skills",

--- a/lang/en.json
+++ b/lang/en.json
@@ -17,7 +17,6 @@
     "dishonored.actor.character.archetype": "Archetype",
     "dishonored.actor.character.outlook": "Outlook",
     "dishonored.actor.character.void": "Void Points Track",
-    "dishonored.actor.skisty.select": "Select",
     "dishonored.actor.skisty.mod": "Modifier",
     "dishonored.actor.skisty.check": "Perform Check",
     "dishonored.actor.skill.title": "Skills",

--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -7,8 +7,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "character"],
-            template: "systems/FVTT-Dishonored/templates/actors/character-sheet.html",
+            classes: ["dishonored", "sheet", "actor", "character"],
             width: 700,
             height: 735,
             dragDrop: [{
@@ -17,6 +16,14 @@ export class DishonoredCharacterSheet extends ActorSheet {
             }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.actor.limited) return "systems/FVTT-Dishonored/templates/actors/limited-sheet.html";
+        return `systems/FVTT-Dishonored/templates/actors/character-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 
@@ -79,7 +86,10 @@ export class DishonoredCharacterSheet extends ActorSheet {
         super.activateListeners(html);
         
         // Opens the class DishonoredSharedActorFunctions for access at various stages.
-        let dishonoredActor = new DishonoredSharedActorFunctions()
+        let dishonoredActor = new DishonoredSharedActorFunctions();
+
+        // If the player has limited access to the actor, there is nothing to see here. Return.
+        if ( !game.user.isGM && this.actor.limited) return;
 
         // We use i alot in for loops. Best to assign it now for use later in multiple places.
         var i;
@@ -89,7 +99,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
         var voidPointsMax = html.find('#max-void')[0].value;
         for (i = 1; i <= voidPointsMax; i++) {
             var div = document.createElement("DIV");
-            div.className = "voidbox";
+            div.className = "box";
             div.id = "void-" + i;
             div.innerHTML = i;
             div.style = "width: calc(100% / " + html.find('#max-void')[0].value + ");"
@@ -111,7 +121,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
         }
         for (i = 1; i <= stressTrackMax; i++) {
             var div = document.createElement("DIV");
-            div.className = "stressbox";
+            div.className = "box";
             div.id = "stress-" + i;
             div.innerHTML = i;
             div.style = "width: calc(100% / " + html.find('#max-stress')[0].value + ");"
@@ -124,7 +134,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
         var i;
         for (i = 1; i <= expPointsMax; i++) {
             var div = document.createElement("DIV");
-            div.className = "expbox";
+            div.className = "box";
             div.id = "exp-" + i;
             div.innerHTML = i;
             div.style = "width: calc(100% / " + expPointsMax + ");"
@@ -137,7 +147,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
         var i;
         for (i = 1; i <= momPointsMax; i++) {
             var div = document.createElement("DIV");
-            div.className = "mombox";
+            div.className = "box";
             div.id = "mom-" + i;
             div.innerHTML = i;
             div.style = "width: calc(100% / " + momPointsMax + ");"
@@ -148,72 +158,56 @@ export class DishonoredCharacterSheet extends ActorSheet {
         dishonoredActor.dishonoredRenderTracks(html, stressTrackMax, voidPointsMax, expPointsMax, momPointsMax);
 
         // This allows for each item-edit image to link open an item sheet. This uses Simple Worldbuilding System Code.
-        html.find('.item-edit').click(ev => {
-            const li = $(ev.currentTarget).parents(".item");
+        html.find('.control.edit').click(ev => {
+            const li = $(ev.currentTarget).parents(".entry");
             const item = this.actor.getOwnedItem(li.data("itemId"));
             item.sheet.render(true);
         });
 
-        // This if statement checks if the form is editable, if not it hides controls used by the owner, then aborts any more of the script.
+        // This if statement checks if the form is editable, if not it hides control used by the owner, then aborts any more of the script.
         if (!this.options.editable) {
-            // This hides the ability to Perform a Skill Test for the character
+            // This hides the ability to Perform a Skill Test for the character.
             for (i = 0; i < html.find('.check-button').length; i++) {
                 html.find('.check-button')[i].style.display = 'none';
             }
-            // This hides the ability to change the amount of Void Points the character has
+            // This hides the ability to change the amount of Void Points the character has.
             for (i = 0; i < html.find('.voidchange').length; i++) {
                 html.find('.voidchange')[i].style.display = 'none';
             }
-            // This hides all add item images
-            for (i = 0; i < html.find('.add-item').length; i++) {
-                html.find('.add-item')[i].style.display = 'none';
+            // This hides all add and delete item images.
+            for (i = 0; i < html.find('.control.create').length; i++) {
+                html.find('.control.create')[i].style.display = 'none';
             }
-            // This hides all remove item images
-            for (i = 0; i < html.find('.item-delete').length; i++) {
-                html.find('.item-delete')[i].style.display = 'none';
+            for (i = 0; i < html.find('.control.delete').length; i++) {
+                html.find('.control.delete')[i].style.display = 'none';
             }
             // This hides all skill and style check boxes (and titles)
-            for (i = 0; i < html.find('.stat-selector-text').length; i++) {
-                html.find('.stat-selector-text')[i].style.display = 'none';
+            for (i = 0; i < html.find('.selector').length; i++) {
+                html.find('.selector')[i].style.display = 'none';
             }
-            for (i = 0; i < html.find('.style-roll-selector').length; i++) {
-                html.find('.style-roll-selector')[i].style.display = 'none';
-            }
-            for (i = 0; i < html.find('.skill-roll-selector').length; i++) {
-                html.find('.skill-roll-selector')[i].style.display = 'none';
+            for (i = 0; i < html.find('.selector').length; i++) {
+                html.find('.selector')[i].style.display = 'none';
             }
             // Remove hover CSS from clickables that are no longer clickable.
-            for (i = 0; i < html.find('.mombox').length; i++) {
-                html.find('.mombox')[i].classList.add("unset-clickables");
+            for (i = 0; i < html.find('.box').length; i++) {
+                html.find('.box')[i].classList.add("unset-clickables");
             }
-            for (i = 0; i < html.find('.expbox').length; i++) {
-                html.find('.expbox')[i].classList.add("unset-clickables");
-            }
-            for (i = 0; i < html.find('.stressbox').length; i++) {
-                html.find('.stressbox')[i].classList.add("unset-clickables");
-            }
-            for (i = 0; i < html.find('.voidbox').length; i++) {
-                html.find('.voidbox')[i].classList.add("unset-clickables");
-            }
-            for (i = 0; i < html.find('.cs-item-img').length; i++) {
-                html.find('.cs-item-img')[i].classList.add("unset-clickables");
-            }
-            for (i = 0; i < html.find('.item-create').length; i++) {
-                html.find('.item-create')[i].classList.add("unset-clickables");
+            for (i = 0; i < html.find('.rollable').length; i++) {
+                html.find('.rollable')[i].classList.add("unset-clickables");
             }
 
             return;
         };
 
         // This allows for all items to be rolled, it gets the current targets type and id and sends it to the rollGenericItem function.
-        html.find('.cs-item-img').click(ev =>{
-            var itemType = $(ev.currentTarget).parents(".item")[0].getAttribute("data-item-type");
-            var itemId = $(ev.currentTarget).parents(".item")[0].getAttribute("data-item-id");
+        html.find('.rollable').click(ev =>{
+            var itemType = $(ev.currentTarget).parents(".entry")[0].getAttribute("data-item-type");
+            var itemId = $(ev.currentTarget).parents(".entry")[0].getAttribute("data-item-id");
             dishonoredActor.rollGenericItem(event, itemType, itemId, this.actor);
         })
 
         // Allows item-create images to create an item of a type defined individually by each button. This uses code found via the Foundry VTT System Tutorial.
-        html.find('.item-create').click(ev => {
+        html.find('.control.create').click(ev => {
             event.preventDefault();
             const header = event.currentTarget;
             const type = header.dataset.type;
@@ -229,8 +223,8 @@ export class DishonoredCharacterSheet extends ActorSheet {
         });
 
         // Allows item-delete images to allow deletion of the selected item. This uses Simple Worldbuilding System Code.
-        html.find('.item-delete').click(ev => {
-            const li = $(ev.currentTarget).parents(".item");
+        html.find('.control.delete').click(ev => {
+            const li = $(ev.currentTarget).parents(".entry");
             this.actor.deleteOwnedItem(li.data("itemId"));
             li.slideUp(200, () => this.render(false));
         });
@@ -365,9 +359,9 @@ export class DishonoredCharacterSheet extends ActorSheet {
 
         // Turns the Skill checkboxes into essentially a radio button. It removes any other ticks, and then checks the new skill.
         // Finally a submit is required as data has changed.
-        html.find('.skill-roll-selector').click(ev => {
+        html.find('.selector.skill').click(ev => {
             for (i = 0; i <= 5; i++) {
-                html.find('.skill-roll-selector')[i].checked = false;
+                html.find('.selector.skill')[i].checked = false;
             }
             $(ev.currentTarget)[0].checked = true;
             this.submit();
@@ -375,9 +369,9 @@ export class DishonoredCharacterSheet extends ActorSheet {
 
         // Turns the Style checkboxes into essentially a radio button. It removes any other ticks, and then checks the new style.
         // Finally a submit is required as data has changed.
-        html.find('.style-roll-selector').click(ev => {
+        html.find('.selector.style').click(ev => {
             for (i = 0; i <= 5; i++) {
-                html.find('.style-roll-selector')[i].checked = false;
+                html.find('.selector.style')[i].checked = false;
             }
             $(ev.currentTarget)[0].checked = true;
             this.submit();
@@ -386,15 +380,15 @@ export class DishonoredCharacterSheet extends ActorSheet {
         // If the check-button is clicked it grabs the selected skill and the selected style and fires the method rollSkillTest. See actor.js for further info.
         html.find('.check-button').click(ev => {
             for (i = 0; i <= 5; i++) {
-                if (html.find('.skill-roll-selector')[i].checked === true) {
-                    var selectedSkill = html.find('.skill-roll-selector')[i].id;
+                if (html.find('.selector.skill')[i].checked === true) {
+                    var selectedSkill = html.find('.selector.skill')[i].id;
                     var selectedSkill = selectedSkill.slice(0, -9)
                     var selectedSkillValue = html.find('#'+selectedSkill)[0].value;
                 }
             }
             for (i = 0; i <= 5; i++) {
-                if (html.find('.style-roll-selector')[i].checked === true) {
-                    var selectedStyle = html.find('.style-roll-selector')[i].id;
+                if (html.find('.selector.style')[i].checked === true) {
+                    var selectedStyle = html.find('.selector.style')[i].id;
                     var selectedStyle = selectedStyle.slice(0, -9)
                     var selectedStyleValue = html.find('#'+selectedStyle)[0].value;
                 }

--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -19,6 +19,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
 
     /* -------------------------------------------- */
 
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
     /** @override */
     get template() {
         if ( !game.user.isGM && this.actor.limited) return "systems/FVTT-Dishonored/templates/actors/limited-sheet.html";

--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -172,6 +172,36 @@ export class DishonoredCharacterSheet extends ActorSheet {
             for (i = 0; i < html.find('.item-delete').length; i++) {
                 html.find('.item-delete')[i].style.display = 'none';
             }
+            // This hides all skill and style check boxes (and titles)
+            for (i = 0; i < html.find('.stat-selector-text').length; i++) {
+                html.find('.stat-selector-text')[i].style.display = 'none';
+            }
+            for (i = 0; i < html.find('.style-roll-selector').length; i++) {
+                html.find('.style-roll-selector')[i].style.display = 'none';
+            }
+            for (i = 0; i < html.find('.skill-roll-selector').length; i++) {
+                html.find('.skill-roll-selector')[i].style.display = 'none';
+            }
+            // Remove hover CSS from clickables that are no longer clickable.
+            for (i = 0; i < html.find('.mombox').length; i++) {
+                html.find('.mombox')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.expbox').length; i++) {
+                html.find('.expbox')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.stressbox').length; i++) {
+                html.find('.stressbox')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.voidbox').length; i++) {
+                html.find('.voidbox')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.cs-item-img').length; i++) {
+                html.find('.cs-item-img')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.item-create').length; i++) {
+                html.find('.item-create')[i].classList.add("unset-clickables");
+            }
+
             return;
         };
 

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -18,7 +18,7 @@ export class DishonoredNPCSheet extends ActorSheet {
     }
 
     /* -------------------------------------------- */
-
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
     /** @override */
     get template() {
         if ( !game.user.isGM && this.actor.limited) return "systems/FVTT-Dishonored/templates/actors/limited-sheet.html";

--- a/module/actors/sheets/npc-sheet.js
+++ b/module/actors/sheets/npc-sheet.js
@@ -119,6 +119,26 @@ export class DishonoredNPCSheet extends ActorSheet {
             for (i = 0; i < html.find('.item-delete').length; i++) {
                 html.find('.item-delete')[i].style.display = 'none';
             }
+            // This hides all skill and style check boxes (and titles)
+            for (i = 0; i < html.find('.stat-selector-text').length; i++) {
+                html.find('.stat-selector-text')[i].style.display = 'none';
+            }
+            for (i = 0; i < html.find('.style-roll-selector').length; i++) {
+                html.find('.style-roll-selector')[i].style.display = 'none';
+            }
+            for (i = 0; i < html.find('.skill-roll-selector').length; i++) {
+                html.find('.skill-roll-selector')[i].style.display = 'none';
+            }
+            // Remove hover CSS from clickables that are no longer clickable.
+            for (i = 0; i < html.find('.stressbox').length; i++) {
+                html.find('.stressbox')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.cs-item-img').length; i++) {
+                html.find('.cs-item-img')[i].classList.add("unset-clickables");
+            }
+            for (i = 0; i < html.find('.item-create').length; i++) {
+                html.find('.item-create')[i].classList.add("unset-clickables");
+            }
             return;
         };
 

--- a/module/dishonored.js
+++ b/module/dishonored.js
@@ -39,30 +39,30 @@ import {
 
 Hooks.once("init", async function() {
     // Splash Screen
-    console.log(`Initializing Dishonored Tabletop Roleplaying Game System`);
-    console.log('                                                        @@')
-    console.log('         @                                            @@')
-    console.log('@         @@                     @      @@         @@@@')
-    console.log('  @@       @@@                 @@@   @@@        @@@@')
-    console.log('    @@@@     @@@@@@@@@@@@@@@@@@@@    @@      @@@@@')
-    console.log('      @@@@    @@@@            @@   @@@     @@@@@')
-    console.log('        @@@@@   @     @@@@@@@@   @@@    @@@@@      @@')
-    console.log('  @@@      @@@@ @@@@@@@       @@@@@  @@@@@@    @@@@')
-    console.log('      @@@@    @@@@              @ @@@@@@   @@@@@')
-    console.log('          @@@@   @              @@@@@@  @@@  @@@')
-    console.log('                    @@@@@@@@@@@@@@@@          @@@')
-    console.log('                  @@@@        @@@@            @@@')
-    console.log('                  @@    @@@@@   @@@  @@@@@     @@')
-    console.log('                        @@@@   @@@   @@@@@     @@')
-    console.log('                    @@@       @@@@            @@@')
-    console.log('        @@@@  @  @@@@@@@@@@@@@@               @@')
-    console.log('        @@ @@  @@@@@                         @@@')
-    console.log('             @@@@                    @@    @@@')
-    console.log('            @@                         @@@@@@')
-    console.log('          @                              @@@@')
-    console.log('                                            @@@')
-    console.log('                                               @@@')
-    console.log('                                                  @@')
+    console.log(`Initializing Dishonored Tabletop Roleplaying Game System
+                                                            @@
+             @                                            @@
+    @         @@                     @      @@         @@@@
+      @@       @@@                 @@@   @@@        @@@@
+        @@@@     @@@@@@@@@@@@@@@@@@@@    @@      @@@@@
+          @@@@    @@@@            @@   @@@     @@@@@
+            @@@@@   @     @@@@@@@@   @@@    @@@@@      @@
+      @@@      @@@@ @@@@@@@       @@@@@  @@@@@@    @@@@
+          @@@@    @@@@              @ @@@@@@   @@@@@
+              @@@@   @              @@@@@@  @@@  @@@
+                        @@@@@@@@@@@@@@@@          @@@
+                      @@@@        @@@@            @@@
+                      @@    @@@@@   @@@  @@@@@     @@
+                            @@@@   @@@   @@@@@     @@
+                        @@@       @@@@            @@@
+            @@@@  @  @@@@@@@@@@@@@@               @@
+            @@ @@  @@@@@                         @@@
+                 @@@@                    @@    @@@
+                @@                         @@@@@@
+              @                              @@@@
+                                                @@@
+                                                   @@@
+                                                      @@`)
 
     // Define initiative for the system.
     CONFIG.Combat.initiative = {

--- a/module/items/armor-sheet.js
+++ b/module/items/armor-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredArmorSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "armor"],
+            classes: ["dishonored", "sheet", "item", "armor"],
             template: "systems/FVTT-Dishonored/templates/items/armor-sheet.html",
             width: 500,
             height: 250,

--- a/module/items/armor-sheet.js
+++ b/module/items/armor-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredArmorSheet extends ItemSheet {
 
     /** @override */

--- a/module/items/bonecharm-sheet.js
+++ b/module/items/bonecharm-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredBonecharmSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "bonecharm"],
+            classes: ["dishonored", "sheet", "item", "bonecharm"],
             template: "systems/FVTT-Dishonored/templates/items/bonecharm-sheet.html",
             width: 500,
             height: 250,

--- a/module/items/bonecharm-sheet.js
+++ b/module/items/bonecharm-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredBonecharmSheet extends ItemSheet {
 
     /** @override */

--- a/module/items/contact-sheet.js
+++ b/module/items/contact-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredContactSheet extends ItemSheet {
 
     /** @override */
@@ -42,28 +38,29 @@ export class DishonoredContactSheet extends ItemSheet {
     activateListeners(html) {
         super.activateListeners(html);
 
-        var appId = this.appId;
-
-        // Everything below here is only needed if the sheet is editable
+        // If the sheet is not editable, hide the Send2Actor button (as the player shouldn't be able to edit this!). Also bump up the size of the Description editor.
         if (!this.options.editable) {
             html.find('.send2actor')[0].style.display = 'none';
             html.find('.description')[0].style.height = 'calc(100% - 50px)';
             return;
         }
 
+        // Check if the user has the role set in the system settings. If not hide the button from the user.
         if (!game.user.hasRole(game.settings.get("FVTT-Dishonored", "send2ActorPermissionLevel"))) {
             html.find('.send2actor')[0].style.display = 'none';
         }
         else {
             html.find('.send2actor').click(ev => {
-                var name = $("[data-appid="+appId+"]").find('#name')[0].value;
-                var description = $("[data-appid="+appId+"]").find('.editor-content')[0].innerHTML;
-                var img = $("[data-appid="+appId+"]").find('.img')[0].getAttribute("src");
+                // Grab the value of the name field, the editor content and the img src and send this to the send2Actor method.
+                var name = html.find('#name')[0].value;
+                var description = html.find('.editor-content')[0].innerHTML;
+                var img = html.find('.img')[0].getAttribute("src");
                 this.send2Actor(name, description, img).then(created => ui.notifications.info("NPC with the name: '"+name+"' has been created!"));
             });
         }
     }
 
+    // Create an actor with the name, img and notes set from the contact - the actor is hardcoded as NPC here.
     async send2Actor(name, description, img) {
         let actor = await Actor.create({
             name: name,

--- a/module/items/contact-sheet.js
+++ b/module/items/contact-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredContactSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "contact"],
+            classes: ["dishonored", "sheet", "item", "contact"],
             template: "systems/FVTT-Dishonored/templates/items/contact-sheet.html",
             width: 500,
             height: 400,
@@ -46,18 +46,19 @@ export class DishonoredContactSheet extends ItemSheet {
 
         // Everything below here is only needed if the sheet is editable
         if (!this.options.editable) {
-            html.find('.send2actor-button')[0].style.display = 'none';
+            html.find('.send2actor')[0].style.display = 'none';
+            html.find('.description')[0].style.height = 'calc(100% - 50px)';
             return;
         }
 
         if (!game.user.hasRole(game.settings.get("FVTT-Dishonored", "send2ActorPermissionLevel"))) {
-            html.find('.send2actor-button')[0].style.display = 'none';
+            html.find('.send2actor')[0].style.display = 'none';
         }
         else {
-            html.find('.send2actor-button').click(ev => {
+            html.find('.send2actor').click(ev => {
                 var name = $("[data-appid="+appId+"]").find('#name')[0].value;
                 var description = $("[data-appid="+appId+"]").find('.editor-content')[0].innerHTML;
-                var img = $("[data-appid="+appId+"]").find('.item-img')[0].getAttribute("src");
+                var img = $("[data-appid="+appId+"]").find('.img')[0].getAttribute("src");
                 this.send2Actor(name, description, img).then(created => ui.notifications.info("NPC with the name: '"+name+"' has been created!"));
             });
         }

--- a/module/items/focus-sheet.js
+++ b/module/items/focus-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredFocusSheet extends ItemSheet {
 
     /** @override */
@@ -22,6 +18,7 @@ export class DishonoredFocusSheet extends ItemSheet {
         const data = super.getData();
         data.dtypes = ["String", "Number", "Boolean"];
 
+        //Checks if the rating of the focus is above 5 or 2. If it exceeds these bounds it sets it to the closest limit. (i.e. 1 is set to 2)
         if (data.data.rating > 5) data.data.rating = 5;
         if (data.data.rating < 2) data.data.rating = 2;
 

--- a/module/items/focus-sheet.js
+++ b/module/items/focus-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredFocusSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "focus"],
+            classes: ["dishonored", "sheet", "item", "focus"],
             template: "systems/FVTT-Dishonored/templates/items/focus-sheet.html",
             width: 500,
             height: 200,

--- a/module/items/item-sheet.js
+++ b/module/items/item-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredItemSheet extends ItemSheet {
 
     /** @override */

--- a/module/items/item-sheet.js
+++ b/module/items/item-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredItemSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "item"],
+            classes: ["dishonored", "sheet", "item", "item"],
             template: "systems/FVTT-Dishonored/templates/items/item-sheet.html",
             width: 500,
             height: 480,

--- a/module/items/power-sheet.js
+++ b/module/items/power-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredPowerSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "power"],
+            classes: ["dishonored", "sheet", "item", "power"],
             template: "systems/FVTT-Dishonored/templates/items/power-sheet.html",
             width: 500,
             height: 250,

--- a/module/items/power-sheet.js
+++ b/module/items/power-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredPowerSheet extends ItemSheet {
 
     /** @override */

--- a/module/items/talent-sheet.js
+++ b/module/items/talent-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredTalentSheet extends ItemSheet {
 
     /** @override */

--- a/module/items/talent-sheet.js
+++ b/module/items/talent-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredTalentSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "talent"],
+            classes: ["dishonored", "sheet", "item", "talent"],
             template: "systems/FVTT-Dishonored/templates/items/talent-sheet.html",
             width: 500,
             height: 250,

--- a/module/items/weapon-sheet.js
+++ b/module/items/weapon-sheet.js
@@ -7,7 +7,7 @@ export class DishonoredWeaponSheet extends ItemSheet {
     /** @override */
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            classes: ["dishonored", "sheet", "weapon"],
+            classes: ["dishonored", "sheet", "item", "weapon"],
             template: "systems/FVTT-Dishonored/templates/items/weapon-sheet.html",
             width: 565,
             height: 400,

--- a/module/items/weapon-sheet.js
+++ b/module/items/weapon-sheet.js
@@ -1,7 +1,3 @@
-/**
- * Extend the basic ItemSheet with some very simple modifications
- * @extends {ItemSheet}
- */
 export class DishonoredWeaponSheet extends ItemSheet {
 
     /** @override */

--- a/module/roll.js
+++ b/module/roll.js
@@ -61,28 +61,30 @@ export class DishonoredRoll {
 
         // Build a dynamic html using the variables from above.
         let html = `
-			<div class="dice-roll">
-				<div class="dice-result">
-					<div class="dice-formula">
-						<table>
-							<tr>
-								<td> ` + dicePool + `d20 </td>
-								<td> Target:` + checkTarget + ` </td>
-								<td> Focus:` + focusTarget + ` </td>
-							</tr>
-						</table>
-					</div>
-					<div class="dice-tooltip" style="display: block;">
-						<section class="tooltip-part">
-							<div class="dice">
-								<ol class="dice-rolls" style="display: flex; justify-content: center;">` + diceString + `</ol>
-							</div>
-						</section>
-					</div>` +
-            complicationText +
-            `<h4 class="dice-total">` + successText + `</h4>
-				</div>
-			</div>
+            <div class="dishonored roll skill">
+                <div class="dice-roll">
+                    <div class="dice-result">
+                        <div class="dice-formula">
+                            <table class="aim">
+                                <tr>
+                                    <td> ` + dicePool + `d20 </td>
+                                    <td> Target:` + checkTarget + ` </td>
+                                    <td> Focus:` + focusTarget + ` </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <div class="dice-tooltip">
+                            <section class="tooltip-part">
+                                <div class="dice">
+                                    <ol class="dice-rolls">` + diceString + `</ol>
+                                </div>
+                            </section>
+                        </div>` +
+                        complicationText +
+                        `<h4 class="dice-total">` + successText + `</h4>
+                    </div>
+                </div>
+            </div>
         `
         // Check if the dice3d module exists (Dice So Nice). If it does, post a roll in that and then send to chat after the roll has finished. If not just send to chat.
         if(game.dice3d) {
@@ -206,18 +208,20 @@ export class DishonoredRoll {
         let varField = variable ? variable : '';
         // Builds a generic HTML template that is used for all items.
         let html = `
-            <div class='dishonored dice-roll'>
-                <div class="dice-result">
-                    <div class='item-roll-header dice-formula'>
-                        <img class='item-roll-img' src=`+img+`></img>
-                        <h1>`+name+`</h1>
-                    </div>
-                    `+varField+`
-                    <div class="dice-tooltip" style="display: block;">`+descField+`</div>
-                    <div class='tags'> 
-                        `+tagField+`
-                    </div>
-                <div>
+            <div class='dishonored roll generic'>
+                <div class='dice-roll'>
+                    <div class="dice-result">
+                        <div class='dice-formula title'>
+                            <img class='img' src=`+img+`></img>
+                            <h1>`+name+`</h1>
+                        </div>
+                        `+varField+`
+                        <div class="dice-tooltip">`+descField+`</div>
+                        <div class='tags'> 
+                            `+tagField+`
+                        </div>
+                    <div>
+                </div>
             </div>
         `;
         // Returns it for the sendToChat to utilise.

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -1,462 +1,42 @@
-/* .dishonored {
-  Sheet Tabs
-  Items List
-  Attributes
-} */
-
-.dishonored .header-fields {
-    flex: 1;
-    /* For when I start changing the background to a more Dishonored Style one:
-    position: sticky;
-    top: 0; */
-}
-
-.dishonored .header-fields .row {
-    display: flex;
-    flex-direction: row;
-    text-align: center;
-}
-
-.dishonored .header-fields .column {
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-    width: 100%;
-}
-
-.dishonored .experience-title {
-    text-align: center;
-    font-size: 14px;
-}
-
-.dishonored .experience-track {
-    display: flex;
-    flex-direction: row;
-}
-
-.dishonored .expbar {
-    width: 100%;
-}
-
-.dishonored .expbox {
-    height: 14px;
-    border: 1px solid #191919;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-    font-size: 8pt;
-    text-align: center;
-}
-
-.dishonored .expbox:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .momentum-title {
-    text-align: center;
-}
-
-.dishonored .momentum-track {
-    display: flex;
-    flex-direction: row;
-}
-
-.dishonored .mombar {
-    width: 100%;
-}
-
-.dishonored .mombox {
-    width: calc(100%/6);
-    height: 14px;
-    border: 1px solid #191919;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-    font-size: 8pt;
-    text-align: center;
-}
-
-.dishonored .mombox:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .main {
-    flex: 1;
-}
-
-.dishonored .main .row {
-    display: flex;
-    flex-direction: row;
-    text-align: center;
-    max-height: 250px;
-}
-
-.dishonored .main .column {
-    flex-direction: column;
-    text-align: center;
-    width: 33.3333333333%;
-    overflow-y: auto;
-}
-
-.dishonored .stat-flex-row {
-    display: flex;
-    flex-direction: row;
-}
-
-.dishonored .stat-flex-row .stat-field {
-    width: 30%;
-}
-
-.dishonored .stat-flex-row .stat-text {
-    width: 55%;
-}
+/* Window Content Overrides */
 
 .dishonored .window-content {
-    height: 100%;
-    padding: 5px;
+    background: #dadada !important;
+    padding: 0;
 }
 
-.dishonored .sheet-header {
-    height: 100px;
-    overflow: hidden;
+
+
+/* Globals */
+
+.dishonored .bold {
+    font-weight: bold;
+}
+
+.dishonored .title {
+    text-align: center;
+    font-size: 14pt;
+}
+
+.dishonored .row {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    margin-bottom: 10px;
-}
-
-.dishonored .mainflex {
-    display: flex;
-    flex-direction: row;
-}
-
-.dishonored .stressbar {
-    width: 100%;
-}
-
-.dishonored .stressbox {
-    height: 14px;
-    border: 1px solid #191919;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-    font-size: 8pt;
     text-align: center;
 }
 
-.dishonored .stressbox:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .skill-roll-selector {
-    width: 15%;
-    border: 1px solid;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-}
-
-.dishonored .skill-roll-selector:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .style-roll-selector {
-    width: 15%;
-    border: 1px solid;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-}
-
-.dishonored .style-roll-selector:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .voidbar {
-    width: 100%;
-}
-
-.dishonored .voidbox {
-    height: 14px;
-    border: 1px solid #191919;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-    font-size: 8pt;
+.dishonored .row .column {
+    flex-direction: column;
     text-align: center;
 }
 
-.dishonored .voidbox:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .voidchange {
-    width: 5%;
-    height: 14px;
-    border: 1px solid #191919;
-    border-collapse: collapse;
-    padding: 0px;
-    display: block;
-    font-size: 8pt;
-    text-align: center;
-}
-
-.dishonored .voidchange:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .check-button {
-    width: 75%;
-    height: 30px;
+.dishonored .btn {
     background-color: #000000;
     color: #ffffff;
-    line-height: 30px;
-    margin: 5px 12.5%;
-    font-size: 14pt;
     border-radius: 4px;
     border: 1px solid #ffffff;
 }
 
-.dishonored .check-button:hover {
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .notes {
-    height: 200px;
-    text-align: left;
-}
-
-.dishonored .notes .editor {
-    height: 100%;
-}
-
-.dishonored .section-title {
-    font-size: 18pt;
-    font-weight: bold;
-}
-
-.dishonored .sub-section-title {
-    border: 1px solid #000000;
-    background-color: rgb(255, 255, 255, 0.3);
-}
-
-.dishonored .item-section {
-    display: flex;
-    flex-direction: row;
-}
-
-.dishonored .item-section .title {
-    width: 100%;
-    text-align: center;
-}
-
-/* .dishonored .add-item {
-    font-size: 10pt;
-    line-height: 30px;
-    width: 5%;
-} */
-
-.dishonored .add-item-sub {
-    font-size: 10pt;
-    width: 5%;
-}
-
-.dishonored .headings {
-    font-size: 14pt;
-}
-
-.dishonored .advisory {
-    font-weight: bold;
-}
-
-.dishonored .item-flex {
-    display: flex;
-    flex-direction: row;
-}
-
-.dishonored .item-image {
-    width: 26px;
-}
-
-.dishonored .item-name {
-    width: calc(100% - 58px);
-}
-
-.dishonored .item-controls {
-    width: 32px;
-}
-
-.dishonored .item-two-section-main {
-    width: calc(3*((100% - 58px)/4));
-}
-
-.dishonored .item-two-section-sub {
-    width: calc((100% - 58px)/4);
-}
-
-.dishonored .item-two-section {
-    width: calc((100% - 58px)/2);
-}
-
-.dishonored .manabox input {
-    height: 17px;
-}
-
-.dishonored .manamax input {
-    box-shadow: none;
-    cursor: default;
-    color: grey;
-}
-
-.dishonored .collectables {
-    width: calc(100% /4);
-}
-
-.dishonored .collectables input {
-    height: 17px;
-}
-
-
-.dishonored .item-img {
-   width: 50px;
-}
-
-.dishonored .item-header-input {
-   width: 50%;
-   font-weight: bold;
-   font-size: 12pt;
-}
-
-.dishonored .item-header-input-single {
-    width: 100%;
-    font-weight: bold;
-    font-size: 12pt;
- }
-
-.dishonored .item-header-input-main {
-    width: 80%;
-    font-weight: bold;
-    font-size: 12pt;
- }
-
- .dishonored .item-header-input-mini-main {
-    width: 80%;
-    font-weight: bold;
-    font-size: 12pt;
- }
-
- .dishonored .item-header-input-sub {
-    width: 20%;
-    font-weight: bold;
-    font-size: 12pt;
- }
-
-.dishonored .description {
-    height: calc(100% - 50px);
-}
-
-.dishonored .description .editor {
-    height: 100%;
-}
-
-.dishonored .note-npc-section {
-    width:100%;
-}
-
-.dishonored .weapon-cell {
-    width: 25%;
-    display: flex;
-    flex-direction: row;
-    text-align: left;
-}
-
-.dishonored .weapon-cell .label {
-    width: 75%;
-    font-weight: bold;
-    line-height: 26px;
-}
-
-.dishonored .weapon-cell .input {
-    width: 25%;
-}
-
-.dishonored .description-weapon {
-    height: calc(100% - 128px);
-}
-
-.dishonored .description-weapon .editor {
-    height: 100%;
-}
-
-.dishonored .mana {
-    width: 100%;
-    font-size: 16px;
-    text-align: center;
-}
-
-.dishonored .cs-item-img {
-    width: 24px;
-}
-
-.dishonored .cs-item-img:hover {
-    content: url("/icons/svg/d20-grey.svg") !important;
-    box-shadow: 0 0 8px red;
-    cursor: pointer;
-}
-
-.dishonored .item-roll-header{
-    display: flex;
-    flex-direction: row;
-    background: none;
-    border: none;
-    box-shadow: none;
-    line-height: normal;
-    cursor: pointer;
-    text-align: left;
-    word-break: normal;
-}
-
-.dishonored .item-roll-img {
-    height: 45px;
-}
-
-.dishonored .tags {
-    display: flex;
-    flex-direction: row;
-    text-align: center;
-	flex-wrap: wrap;
-}
-
-.dishonored .tag {
-    width: calc(100%/3);
-    font-size: 12px;
-    flex-grow: 1;
-    border: 0.5px solid black;
-    border-radius: 3px;
-    background-color: rgb(255, 255, 255, 0.3);
-}
-
-.dishonored .send2actor-button {
-    width: 100%;
-    height: 20px;
-    background-color: #000000;
-    color: #ffffff;
-    line-height: 20px;
-    font-size: 14pt;
-    border-radius: 4px;
-    border: 1px solid #ffffff;
-}
-
-.dishonored .send2actor-button:hover {
+.dishonored .btn:hover {
     box-shadow: 0 0 8px red;
     cursor: pointer;
 }
@@ -466,4 +46,345 @@
     text-shadow:unset !important;
     cursor:unset !important;
     content:unset !important;
+}
+
+
+
+/* Globals - Trackers */
+
+.dishonored .track {
+    display: flex;
+    flex-direction: row;
+}
+
+.dishonored .track .bar {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+}
+
+.dishonored .track .bar .box {
+    height: 14px;
+    border: 1px solid #191919;
+    border-collapse: collapse;
+    padding: 0px;
+    display: block;
+    font-size: 8pt;
+    text-align: center;
+}
+
+.dishonored .track .bar .box:hover {
+    box-shadow: 0 0 8px red;
+    cursor: pointer;
+}
+
+
+
+/* Actor - Header Section - Globals */
+
+.dishonored.sheet.actor .header-fields {
+    flex: 1;
+    background: rgb(255, 255, 255, 0.9);
+    position: sticky;
+    top: 0;
+    padding: 5px;
+}
+
+.dishonored.sheet.actor .header-fields .row .column {
+    display: flex;
+    width: 100%;
+}
+
+
+
+/* Actor - Header Section - Specific - Trackers */
+
+.dishonored.sheet.actor .header-fields .section.experience .title {
+    font-size: 14px;
+}
+
+
+
+/* Actor - Main Section - Globals */
+
+.dishonored.sheet.actor .main {
+    flex: 1;
+    padding: 5px;
+}
+
+.dishonored.sheet.actor .main .row {
+    max-height: 250px;
+}
+
+.dishonored.sheet.actor .main .row .limited-only {
+    height: 20px;
+}
+
+.dishonored.sheet.actor .main .row .column {
+    width: calc(100% / 3);
+    overflow-y: auto;
+}
+
+.dishonored.sheet.actor .main .row .column .section .title {
+    font-size: 18pt;
+    font-weight: bold;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row {
+    display: flex;
+    flex-direction: row;
+}
+
+.dishonored.sheet.actor .main .row .column .section .entry.row {
+    display: flex;
+    flex-direction: row;
+}
+
+.dishonored.sheet.actor .main .row .column .section .notes {
+    height: 200px;
+    text-align: left;
+}
+
+.dishonored.sheet.actor .main .row .column .section .notes .editor {
+    height: 100%;
+}
+
+
+
+/* Actor - Main Section - Specific - Trackers */
+
+.dishonored.sheet.actor .main .row .column .section .track .bar .voidchange {
+    width: 5%;
+}
+
+
+
+/* Actor - Main Section - Specific - Skills/Styles */
+
+.dishonored.sheet.actor .main .row .column .section .stat.row .field {
+    width: 25%;
+}
+
+.dishonored.sheet.actor .main .row .column .section .stat.row .text {
+    width: calc(75% - 30px);
+}
+
+.dishonored.sheet.actor .main .row .column .section .stat.row .selector-space {
+    width: 30px;
+}
+
+.dishonored.sheet.actor .main .row .column .section .stat.row .selector {
+    border: 1px solid;
+    border-collapse: collapse;
+    padding: 0px;
+    display: block;
+}
+
+.dishonored.sheet.actor .main .row .column .section .stat.row .selector:hover {
+    box-shadow: 0 0 8px red;
+    cursor: pointer;
+}
+
+.dishonored.sheet.actor .main .row .column .section .check-button {
+    width: 75%;
+    height: 30px;
+    line-height: 30px;
+    margin: 5px 12.5%;
+    font-size: 14pt;
+}
+
+
+
+/* Actor - Main Section - Specific - Items */
+
+.dishonored.sheet.actor .main .row .column .section .item.row {
+    border: 1px solid #000000;
+    background-color: rgb(255, 255, 255, 0.3);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .image {
+    width: 26px;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .image img {
+    max-height: 24px;
+    max-width: 24px;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .image .rollable:hover {
+    content: url("/icons/svg/d20-grey.svg");
+    box-shadow: 0 0 8px red;
+    cursor: pointer;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .control {
+    width: 32px;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .column-x1 {
+    width: calc(100% - 58px);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .column-x2 {
+    width: calc((100% - 58px)/2);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .column-x2-big {
+    width: calc(3*((100% - 58px)/4));
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .column-x2-small {
+    width: calc((100% - 58px)/4);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .column-x4 {
+    width: calc(100% /4);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .small input {
+    height: 17px;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .small.disabled input {
+    box-shadow: none;
+    cursor: default;
+    color: grey;
+}
+
+
+
+/* Item - Globals */
+
+.dishonored.sheet.item .header-fields {
+    font-weight: bold;
+    font-size: 12pt;
+}
+
+.dishonored.sheet.item .header-fields .row .img {
+    width: 50px;
+}
+
+.dishonored.sheet.item .header-fields .row .column-x3-big {
+    width: calc(60% - 50px);
+}
+
+.dishonored.sheet.item .header-fields .row .column-x2 {
+    width: calc(50% - 25px);
+}
+
+.dishonored.sheet.item .header-fields .row .column-x2-big {
+    width: calc(80% - 50px);
+}
+
+.dishonored.sheet.item .header-fields .row .column-x1 {
+    width: calc(100% - 50px);
+}
+
+.dishonored.sheet.item .header-fields .row .column-x2-x3-small {
+    width: 20%;
+}
+
+.dishonored.sheet.item .description {
+    height: calc(100% - 50px);
+}
+
+.dishonored.sheet.item .description .editor {
+    height: 100%;
+}
+
+
+
+/* Item - Contact Specific */
+
+.dishonored.sheet.item.contact .header-fields .row .send2actor {
+    width: 100%;
+    height: 20px;
+    line-height: 20px;
+    font-size: 14pt;
+}
+
+.dishonored.sheet.item.contact .description {
+    height: calc(100% - 70px);
+}
+
+
+
+/* Item - Weapon Specific */
+
+.dishonored.sheet.item.weapon .header-fields .row .column-x4 {
+    width: 25%;
+    display: flex;
+    flex-direction: row;
+    text-align: left;
+}
+
+.dishonored.sheet.item.weapon .header-fields .row .column-x4 .label {
+    font-size: 14px;
+    line-height: 26px;
+}
+
+.dishonored.sheet.item.weapon .description {
+    height: calc(100% - 128px);
+}
+
+
+
+/* Roll - Globals */
+
+.dishonored.roll .dice-roll .dice-result .dice-tooltip {
+    display: block;
+}
+
+
+
+/* Roll - Skill Test */
+
+.dishonored.roll.skill .dice-roll .dice-result .dice-formula .aim {
+    margin: 0;
+    background: unset;
+    border: 0;
+}
+
+.dishonored.roll.skill .dice-roll .dice-result .dice-tooltip .dice .dice-rolls {
+    display: flex; 
+    justify-content: center;
+}
+
+
+
+/* Roll - Generic */
+
+.dishonored.roll.generic .dice-roll .dice-result .dice-formula {
+    box-shadow: none;
+    line-height: normal;
+    cursor: pointer;
+    word-break: normal;
+}
+
+.dishonored.roll.generic .dice-roll .dice-result .dice-formula.title {
+    display: flex;
+    flex-direction: row;
+    background: none;
+    border: none;
+    text-align: left;
+}
+
+.dishonored.roll.generic .dice-roll .dice-result .dice-formula .img {
+    height: 45px;
+}
+
+.dishonored.roll.generic .dice-roll .dice-result .tags {
+    display: flex;
+    flex-direction: row;
+    text-align: center;
+	flex-wrap: wrap;
+}
+
+.dishonored.roll.generic .dice-roll .dice-result .tags .tag {
+    width: calc(100%/3);
+    font-size: 12px;
+    flex-grow: 1;
+    border: 0.5px solid black;
+    border-radius: 3px;
+    background-color: rgb(255, 255, 255, 0.3);
 }

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -460,3 +460,10 @@
     box-shadow: 0 0 8px red;
     cursor: pointer;
 }
+
+.dishonored .unset-clickables:hover {
+    box-shadow:unset !important;
+    text-shadow:unset !important;
+    cursor:unset !important;
+    content:unset !important;
+}

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "FVTT-Dishonored",
     "title": "Dishonored Roleplaying Game Unofficial",
     "description": "An unofficial rendition of the Modiphius tabletop role playing game system.",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.7.0",
     "templateVersion": 1,

--- a/template.json
+++ b/template.json
@@ -3,6 +3,7 @@
         "types": ["character", "npc"],
         "templates": {
             "common": {
+                "age": 21,
                 "notes":"",
                 "stress": {
                     "value": 0,
@@ -78,7 +79,6 @@
         "character": {
             "experience": 0,
             "templates": ["common"],
-            "age": 21,
             "mana": {
                 "value": 0,
                 "max": 6

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -51,48 +51,48 @@
             </div>
         </div>
         <div class="header-fields">
-            <div class="experience-section">
-                <div class="experience-title">
+            <div class="section experience">
+                <div class="title bold">
                     {{localize 'dishonored.actor.character.experience'}}
                 </div>
-                <div class="experience-track">
+                <div class="track">
                     <input type="hidden" id="total-exp" name="data.experience" value="{{data.experience}}" data-dtype="Number" />
-                    <div id="bar-exp-renderer" class="mainflex expbar"></div>
+                    <div id="bar-exp-renderer" class=" bar"></div>
                 </div>
             </div>
             <div class="row">
-                <div class="column headings" style="width:40%">
+                <div class="column bold title" style="width:40%">
                     {{localize 'dishonored.actor.character.name'}}
                 </div>
-                <div class="column headings" style="width:25%">
+                <div class="column bold title" style="width:25%">
                     {{localize 'dishonored.actor.character.archetype'}}
                 </div>
-                <div class="column headings" style="width:25%">
+                <div class="column bold title" style="width:25%">
                     {{localize 'dishonored.actor.character.outlook'}}
                 </div>
-                <div class="column headings" style="width:10%">
+                <div class="column bold title" style="width:10%">
                     {{localize 'dishonored.actor.character.age'}}
                 </div>
             </div>
             <div class="row">
-                <div class="column headings" style="width:40%">
+                <div class="column" style="width:40%">
                     <input name="name" type="text" value="{{actor.name}}" placeholder="Name" />
                 </div>
-                <div class="column headings" style="width:25%">
+                <div class="column" style="width:25%">
                     <input name="data.archetype" type="text" value="{{data.archetype}}" />
                 </div>
-                <div class="column headings" style="width:25%">
+                <div class="column" style="width:25%">
                     <input name="data.outlook" type="text" value="{{data.outlook}}" />
                 </div>
-                <div class="column headings" style="width:10%">
+                <div class="column" style="width:10%">
                     <input name="data.age" type="text" value="{{data.age}}" placeholder="21" />
                 </div>
             </div>
             <div class="row">
-                <div class="column headings">
+                <div class="column bold title">
                     <div> {{localize 'dishonored.actor.character.firstTruth'}} </div>
                 </div>
-                <div class="column headings">
+                <div class="column bold title">
                     <div> {{localize 'dishonored.actor.character.secondTruth'}} </div>
                 </div>
             </div>
@@ -104,13 +104,13 @@
                     <input name="data.truth2" type="text" value="{{data.truth2}}" />
                 </div>
             </div>
-            <div class="momentum-section">
-                <div class="momentum-title headings">
+            <div class="section momentum">
+                <div class="title bold">
                     {{localize 'dishonored.actor.character.momentum'}}
                 </div>
-                <div class="momentum-track">
+                <div class="track">
                     <input type="hidden" id="total-mom" name="data.momentum.value" value="{{data.momentum.value}}" data-dtype="Number" />
-                    <div id="bar-mom-renderer" class="mainflex mombar"></div>
+                    <div id="bar-mom-renderer" class=" bar"></div>
                 </div>
             </div>
         </div>
@@ -118,102 +118,102 @@
         <div class="main">
             <div class="row">
                 <div class="column">
-                    <div class="skill-section">
-                        <div class="skill-title section-title">
+                    <div class="section skill">
+                        <div class="title">
                             {{localize 'dishonored.actor.skill.title'}}
                         </div>
-                        <div class="stat-flex-row">
-                            <div class="stat-selector-text advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
-                            <div class="stat-text advisory">{{localize 'dishonored.actor.skill.name'}}</div>
-                            <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
+                        <div class="stat row">
+                            <div class="selector-space"></div>
+                            <div class="text bold">{{localize 'dishonored.actor.skill.name'}}</div>
+                            <div class="field bold">{{localize 'dishonored.actor.skisty.mod'}}</div>
                         </div>
                         {{#each data.skills as |skill key|}}
-                        <div class="stat-flex-row">
-                            <input class="skill-roll-selector" id="{{key}}.selector" type="checkbox" name="data.skills.{{key}}.selected" data-dtype="Boolean" {{checked skill.selected}}>
-                            <div class="stat-text"> {{localize skill.label}} </div>
-                            <input class="stat-field" id="{{key}}" name="data.skills.{{key}}.value" type="text" value="{{skill.value}}" />
+                        <div class="stat row">
+                            <input class="selector skill" id="{{key}}.selector" type="checkbox" name="data.skills.{{key}}.selected" data-dtype="Boolean" {{checked skill.selected}}>
+                            <div class="text"> {{localize skill.label}} </div>
+                            <input class="field" id="{{key}}" name="data.skills.{{key}}.value" type="text" value="{{skill.value}}" />
                         </div>
                         {{/each}}
                         <div class="separator"></div>
-                        <div class="check-section">
-                            <div class="check-button">{{localize 'dishonored.actor.skisty.check'}}</div>
-                        </div>
+                        <div class="check-button btn">{{localize 'dishonored.actor.skisty.check'}}</div>
+
                     </div>
                 </div>
                 <div class="column">
-                    <div class="stress-section">
-                        <div class="stress-title headings">
+                    <div class="section stress">
+                        <div class="title bold">
                             {{localize 'dishonored.actor.character.stress'}}
                         </div>
-                        <div class="mainflex">
+                        <div class="track">
                             <input type="hidden" id="total-stress" name="data.stress.value" value="{{data.stress.value}}" data-dtype="Number" />
                             <input type="hidden" id="max-stress" name="data.stress.max" value="{{data.stress.max}}" data-dtype="Number" />
-                            <div id="bar-stress-renderer" class="mainflex stressbar"></div>
+                            <div id="bar-stress-renderer" class=" bar"></div>
                         </div>
                     </div>
                     <div class="separator"></div>
-                    <div class="img-section">
+                    <div class="section img">
                         <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
                     </div>
                     <div class="separator"></div>
-                    <div class="void-section">
-                        <div class="void-title headings">
+                    <div class="section void">
+                        <div class="title bold">
                             {{localize 'dishonored.actor.character.void'}}
                         </div>
-                        <div class="mainflex">
+                        <div class="track">
                             <input type="hidden" id="total-void" name="data.void.value" value="{{data.void.value}}" data-dtype="Number" />
                             <input type="hidden" id="max-void" name="data.void.max" value="{{data.void.max}}" data-dtype="Number" />
-                            <div class="voidchange" id="decrease-void-max"><i class="fas fa-minus"></i></div>
-                            <div id="bar-void-renderer" class="mainflex voidbar"></div>
-                            <div class="voidchange" id="increase-void-max"><i class="fas fa-plus"></i></div>
+                            <div class="bar">
+                                <div class="voidchange box" id="decrease-void-max"><i class="fas fa-minus"></i></div>
+                                <div id="bar-void-renderer" class="bar"></div>
+                                <div class="voidchange box" id="increase-void-max"><i class="fas fa-plus"></i></div>
+                            </div>
+                            
                         </div>
                     </div>
                 </div>
                 <div class="column">
-                    <div class="style-section">
-                        <div class="style-title section-title">
+                    <div class="section style">
+                        <div class="title">
                             {{localize 'dishonored.actor.style.title'}}
                         </div>
-                        <div class="stat-flex-row">
-                            <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
-                            <div class="stat-text advisory">{{localize 'dishonored.actor.style.name'}}</div>
-                            <div class="stat-selector-text advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
+                        <div class="stat row">
+                            <div class="field bold">{{localize 'dishonored.actor.skisty.mod'}}</div>
+                            <div class="text bold">{{localize 'dishonored.actor.style.name'}}</div>
+                            <div class="selector-space"></div>
                         </div>
                         {{#each data.styles as |style key|}}
-                        <div class="stat-flex-row">
-                            <input class="stat-field" id="{{key}}" name="data.styles.{{key}}.value" type="text" value="{{style.value}}" placeholder="Name" />
-                            <div class="stat-text"> {{localize style.label}} </div>
-                            <input class="style-roll-selector" id="{{key}}.selector" type="checkbox" name="data.styles.{{key}}.selected" data-dtype="Boolean" {{checked style.selected}}>
+                        <div class="stat row">
+                            <input class="field" id="{{key}}" name="data.styles.{{key}}.value" type="text" value="{{style.value}}" placeholder="Name" />
+                            <div class="text"> {{localize style.label}} </div>
+                            <input class="selector style" id="{{key}}.selector" type="checkbox" name="data.styles.{{key}}.selected" data-dtype="Boolean" {{checked style.selected}}>
                         </div>
                         {{/each}}
                         <div class="separator"></div>
-                        <div class="check-section">
-                            <div class="check-button">{{localize 'dishonored.actor.skisty.check'}}</div>
-                        </div>
+                        <div class="check-button btn">{{localize 'dishonored.actor.skisty.check'}}</div>
                     </div>
                 </div>
             </div>
             <div class="row">
                 <div class="column">
-                    <div class="contacts-section">
-                        <div class="contact-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.contact.title'}}</div>
+                    <div class="section contacts">
+                        <div class="title">
+                            {{localize 'dishonored.actor.contact.title'}}
                         </div>
-                        <div class="stat-flex-row sub-section-title">
-                            <div class="item-image"></div>
-                            <div class="item-two-section advisory">{{localize 'dishonored.actor.genericitem.name'}}</div>
-                            <div class="item-two-section advisory">{{localize 'dishonored.actor.contact.relation'}}</div>
-                            <a class="item-controls item-create add-item" title="Create item" data-type="contact"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2 bold">{{localize 'dishonored.actor.genericitem.name'}}</div>
+                            <div class="column-x2 bold">{{localize 'dishonored.actor.contact.relation'}}</div>
+                            <a class="control create" title="Create item" data-type="contact"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "contact")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section">{{item.name}}</h4>
-                            <h4 class="item-two-section">{{item.data.relationship}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2">{{item.name}}</h4>
+                            <h4 class="column-x2">{{item.data.relationship}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
@@ -221,23 +221,23 @@
                     </div>
                 </div>
                 <div class="column">
-                    <div class="talent-section">
-                        <div class="talent-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.talent.title'}}</div>
+                    <div class="section talents">
+                        <div class="title">
+                            {{localize 'dishonored.actor.talent.title'}}
                         </div>
-                        <div class="stat-flex-row sub-section-title">
-                            <div class="item-image"></div>
-                            <div class="item-name advisory">{{localize 'dishonored.actor.genericitem.name'}}</div>
-                            <a class="item-controls item-create add-item" title="Create item" data-type="talent"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x1 bold">{{localize 'dishonored.actor.genericitem.name'}}</div>
+                            <a class="control create" title="Create item" data-type="talent"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "talent")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-name">{{item.name}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x1">{{item.name}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
@@ -245,27 +245,25 @@
                     </div>
                 </div>
                 <div class="column">
-                    <div class="focus-section">
-                        <div class="focus-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.focus.title'}}</div>
-                            
+                    <div class="section focuses">
+                        <div class="title">
+                            {{localize 'dishonored.actor.focus.title'}}
                         </div>
-                        <div class="stat-flex-row sub-section-title">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.genericitem.name'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.focus.rating'}}</div>
-                            <a class="item-controls item-create add-item" title="Create item" data-type="focus"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big bold">{{localize 'dishonored.actor.genericitem.name'}}</div>
+                            <div class="column-x2-small bold">{{localize 'dishonored.actor.focus.rating'}}</div>
+                            <a class="control create" title="Create item" data-type="focus"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "focus")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <!-- <input name="item.data.rating" value="{{item.data.rating}}" data-dtype="Number" /> -->
-                            <h4 class="item-two-section-sub">{{item.data.rating}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 class="column-x2-small">{{item.data.rating}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
@@ -275,8 +273,8 @@
             </div>
             <div class="row">
                 <div class="column">
-                    <div class="note-section">
-                        <div class="note-title section-title">
+                    <div class="section notes">
+                        <div class="title">
                             {{localize 'dishonored.actor.note.title'}}
                         </div>
                         <div class="notes">
@@ -285,118 +283,118 @@
                     </div>
                 </div>
                 <div class="column">
-                    <div class="power-section">
-                        <div class="power-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.power.title'}}</div>
+                    <div class="section powers">
+                        <div class="title">
+                            {{localize 'dishonored.actor.power.title'}}
                         </div>
-                        <div class="stat-flex-row sub-section-title">
-                            <div class="item-image"></div>
-                            <div class="item-name advisory">{{localize 'dishonored.actor.genericitem.name'}}</div>
-                            <a class="item-controls item-create add-item" title="Create item" data-type="power"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x1 bold">{{localize 'dishonored.actor.genericitem.name'}}</div>
+                            <a class="control create" title="Create item" data-type="power"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "power")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-name">{{item.name}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x1">{{item.name}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="stat-flex-row sub-section-title item-section mana advisory">
-                            <div class="manabox"><input name="data.mana.value" type="text" value="{{data.mana.value}}" placeholder="0"/></div>
+                        <div class="row item">
+                            <div class="small"><input name="data.mana.value" type="text" value="{{data.mana.value}}" placeholder="0"/></div>
                             <div class="advisory">/</div>
-                            <div class="manabox manamax"><input id="max-mana" name="data.mana.max" type="text" value="{{data.mana.max}}" readonly/></div>
+                            <div class="small disabled"><input id="max-mana" name="data.mana.max" type="text" value="{{data.mana.max}}" readonly/></div>
                         </div>
                     </div>
                 </div>
                 <div class="column">
-                    <div class="belonging-section">
-                        <div class="belonging-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.belonging.title'}}</div>
+                    <div class="section belongings">
+                        <div class="title">
+                            {{localize 'dishonored.actor.belonging.title'}}
                         </div>
-                        <div class="sub-section-title item-section">
-                            <div class="collectables advisory">{{localize 'dishonored.actor.belonging.collectable.coin'}}</div>
-                            <div class="collectables"><input name="data.coins" type="text" value="{{data.coins}}" placeholder="0"/></div>
-                            <div class="collectables advisory">{{localize 'dishonored.actor.belonging.collectable.rune'}}</div>
-                            <div class="collectables"><input name="data.runes" type="text" value="{{data.runes}}" placeholder="0"/></div>
+                        <div class="row item">
+                            <div class="column-x4 bold">{{localize 'dishonored.actor.belonging.collectable.coin'}}</div>
+                            <div class="column-x4 small"><input name="data.coins" type="text" value="{{data.coins}}" placeholder="0"/></div>
+                            <div class="column-x4 bold">{{localize 'dishonored.actor.belonging.collectable.rune'}}</div>
+                            <div class="column-x4 small"><input name="data.runes" type="text" value="{{data.runes}}" placeholder="0"/></div>
                         </div>
-                        <div class="sub-section-title item-section">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.weapon.title'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.belonging.weapon.dmg'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="weapon"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.weapon.title'}}</div>
+                            <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.weapon.dmg'}}</div>
+                            <a class="control create" title="Create item" data-type="weapon"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "weapon")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <h4 class="item-two-section-sub">{{item.data.damage}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 class="column-x2-small">{{item.data.damage}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="sub-section-title item-section">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.armor.title'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.belonging.armor.protect'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="armor"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.armor.title'}}</div>
+                            <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.armor.protect'}}</div>
+                            <a class="control create" title="Create item" data-type="armor"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "armor")}}
-                        <li id="armor-{{item._id}}" class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <h4 id="protectval-armor-{{item._id}}" class="item-two-section-sub">{{item.data.protection}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li id="armor-{{item._id}}" class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 id="protectval-armor-{{item._id}}" class="column-x2-small">{{item.data.protection}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="sub-section-title item-section">
-                            <div class="item-image">
+                        <div class="row item">
+                            <div class="image">
                                 <!-- 0/3 -->
                             </div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
-                            <div class="item-two-section-sub advisory"></div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
+                            <div class="column-x2-small advisory"></div>
+                            <a class="control create" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "bonecharm")}}
-                        <li class="item item-flex bonecharm" data-item-id="{{item._id}}" data-item-type="{{item.type}}" >
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-name">{{item.name}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry bonecharm" data-item-id="{{item._id}}" data-item-type="{{item.type}}" >
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x1">{{item.name}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="sub-section-title item-section">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.other.title'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.belonging.other.qty'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="item"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.other.title'}}</div>
+                            <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.other.qty'}}</div>
+                            <a class="control create" title="Create item" data-type="item"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "item")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <h4 class="item-two-section-sub">{{item.data.quantity}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 class="column-x2-small">{{item.data.quantity}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -123,7 +123,7 @@
                             {{localize 'dishonored.actor.skill.title'}}
                         </div>
                         <div class="stat-flex-row">
-                            <div class="advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
+                            <div class="stat-selector-text advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
                             <div class="stat-text advisory">{{localize 'dishonored.actor.skill.name'}}</div>
                             <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
                         </div>
@@ -177,7 +177,7 @@
                         <div class="stat-flex-row">
                             <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
                             <div class="stat-text advisory">{{localize 'dishonored.actor.style.name'}}</div>
-                            <div class="advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
+                            <div class="stat-selector-text advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
                         </div>
                         {{#each data.styles as |style key|}}
                         <div class="stat-flex-row">

--- a/templates/actors/limited-sheet.html
+++ b/templates/actors/limited-sheet.html
@@ -1,0 +1,39 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="main-content">
+        <div class="header-fields">
+            <div class="row">
+                <div class="column bold title" style="width:90%">
+                    {{localize 'dishonored.actor.character.name'}}
+                </div>
+                <div class="column bold title" style="width:10%">
+                    {{localize 'dishonored.actor.character.age'}}
+                </div>
+            </div>
+            <div class="row">
+                <div class="column title" style="width:90%">
+                    <input name="name" type="text" value="{{actor.name}}" placeholder="Name" />
+                </div>
+                <div class="column title" style="width:10%">
+                    <input name="data.age" type="text" value="{{data.age}}" placeholder="21" />
+                </div>
+            </div>
+        </div>
+        <div class="main">
+            <div class="row">
+                <div class="limited-only">
+                </div>
+            </div>
+            <div class="row">
+                <div class="column">
+                </div>
+                <div class="column">
+                    <div class="img-section">
+                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
+                    </div>
+                </div>
+                <div class="column">
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -52,19 +52,25 @@
         </div>
         <div class="header-fields">
             <div class="row">
-                <div class="column headings" style="width:50%">
+                <div class="column bold title" style="width:50%">
                     {{localize 'dishonored.actor.character.name'}}
                 </div>
-                <div class="column headings" style="width:50%">
+                <div class="column bold title" style="width:40%">
                     <div> {{localize 'dishonored.actor.character.truth'}} </div>
+                </div>
+                <div class="column bold title" style="width:10%">
+                    {{localize 'dishonored.actor.character.age'}}
                 </div>
             </div>
             <div class="row">
-                <div class="column headings" style="width:50%">
+                <div class="column" style="width:50%">
                     <input name="name" type="text" value="{{actor.name}}" placeholder="Name" />
                 </div>
-                <div class="column" style="width:50%">
+                <div class="column" style="width:40%">
                     <input name="data.truth1" type="text" value="{{data.truth1}}" />
+                </div>
+                <div class="column" style="width:10%">
+                    <input name="data.age" type="text" value="{{data.age}}" placeholder="21" />
                 </div>
             </div>
         </div>
@@ -72,88 +78,85 @@
         <div class="main">
             <div class="row">
                 <div class="column">
-                    <div class="skill-section">
-                        <div class="skill-title section-title">
+                    <div class="section skill">
+                        <div class="title">
                             {{localize 'dishonored.actor.skill.title'}}
                         </div>
-                        <div class="stat-flex-row">
-                            <div class="advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
-                            <div class="stat-text advisory">{{localize 'dishonored.actor.skill.name'}}</div>
-                            <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
+                        <div class="stat row">
+                            <div class="selector-space"></div>
+                            <div class="text bold">{{localize 'dishonored.actor.skill.name'}}</div>
+                            <div class="field bold">{{localize 'dishonored.actor.skisty.mod'}}</div>
                         </div>
                         {{#each data.skills as |skill key|}}
-                        <div class="stat-flex-row">
-                            <input class="skill-roll-selector" id="{{key}}.selector" type="checkbox" name="data.skills.{{key}}.selected" data-dtype="Boolean" {{checked skill.selected}}>
-                            <div class="stat-text"> {{localize skill.label}} </div>
-                            <input class="stat-field" id="{{key}}" name="data.skills.{{key}}.value" type="text" value="{{skill.value}}" />
+                        <div class="stat row">
+                            <input class="selector skill" id="{{key}}.selector" type="checkbox" name="data.skills.{{key}}.selected" data-dtype="Boolean" {{checked skill.selected}}>
+                            <div class="text"> {{localize skill.label}} </div>
+                            <input class="field" id="{{key}}" name="data.skills.{{key}}.value" type="text" value="{{skill.value}}" />
                         </div>
                         {{/each}}
                         <div class="separator"></div>
                     </div>
                 </div>
                 <div class="column">
-                    <div class="stress-section">
-                        <div class="stress-title headings">
+                    <div class="section stress">
+                        <div class="title bold">
                             {{localize 'dishonored.actor.character.stress'}}
                         </div>
-                        <div class="mainflex">
+                        <div class="track">
                             <input type="hidden" id="total-stress" name="data.stress.value" value="{{data.stress.value}}" data-dtype="Number" />
                             <input type="hidden" id="max-stress" name="data.stress.max" value="{{data.stress.max}}" data-dtype="Number" />
-                            <div id="bar-stress-renderer" class="mainflex stressbar"></div>
+                            <div id="bar-stress-renderer" class="bar"></div>
                         </div>
                     </div>
                     <div class="separator"></div>
-                    <div class="img-section">
+                    <div class="section img">
                         <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
                     </div>
                     <div class="separator"></div>
-                    <div class="check-section">
-                        <div class="check-button">{{localize 'dishonored.actor.skisty.check'}}</div>
-                    </div>
+                    <div class="check-button btn">{{localize 'dishonored.actor.skisty.check'}}</div>
                 </div>
                 <div class="column">
-                    <div class="style-section">
-                        <div class="style-title section-title">
+                    <div class="section style">
+                        <div class="title">
                             {{localize 'dishonored.actor.style.title'}}
                         </div>
-                        <div class="stat-flex-row">
-                            <div class="stat-field advisory">{{localize 'dishonored.actor.skisty.mod'}}</div>
-                            <div class="stat-text advisory">{{localize 'dishonored.actor.style.name'}}</div>
-                            <div class="advisory">{{localize 'dishonored.actor.skisty.select'}}</div>
+                        <div class="stat row">
+                            <div class="field bold">{{localize 'dishonored.actor.skisty.mod'}}</div>
+                            <div class="text bold">{{localize 'dishonored.actor.style.name'}}</div>
+                            <div class="selector-space"></div>
                         </div>
                         {{#each data.styles as |style key|}}
-                        <div class="stat-flex-row">
-                            <input class="stat-field" id="{{key}}" name="data.styles.{{key}}.value" type="text" value="{{style.value}}" placeholder="Name" />
-                            <div class="stat-text"> {{localize style.label}} </div>
-                            <input class="style-roll-selector" id="{{key}}.selector" type="checkbox" name="data.styles.{{key}}.selected" data-dtype="Boolean" {{checked style.selected}}>
+                        <div class="stat row">
+                            <input class="field" id="{{key}}" name="data.styles.{{key}}.value" type="text" value="{{style.value}}" placeholder="Name" />
+                            <div class="text"> {{localize style.label}} </div>
+                            <input class="selector style" id="{{key}}.selector" type="checkbox" name="data.styles.{{key}}.selected" data-dtype="Boolean" {{checked style.selected}}>
                         </div>
                         {{/each}}
+                        <div class="separator"></div>
                     </div>
                 </div>
             </div>
             <div class="row">
                 <div class="column">
-                    <div class="focus-section">
-                        <div class="focus-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.focus.title'}}</div>
-                            
+                    <div class="section focuses">
+                        <div class="title">
+                            {{localize 'dishonored.actor.focus.title'}}
                         </div>
-                        <div class="stat-flex-row sub-section-title">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.genericitem.name'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.focus.rating'}}</div>
-                            <a class="item-controls item-create add-item" title="Create item" data-type="focus"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big bold">{{localize 'dishonored.actor.genericitem.name'}}</div>
+                            <div class="column-x2-small bold">{{localize 'dishonored.actor.focus.rating'}}</div>
+                            <a class="control create" title="Create item" data-type="focus"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item id|}}
                         {{#if (eq item.type "focus")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <!-- <input name="item.data.rating" value="{{item.data.rating}}" data-dtype="Number" /> -->
-                            <h4 class="item-two-section-sub">{{item.data.rating}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 class="column-x2-small">{{item.data.rating}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
@@ -161,23 +164,23 @@
                     </div>
                 </div>
                 <div class="column">
-                    <div class="power-section">
-                        <div class="power-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.power.title'}}</div>
+                    <div class="section powers">
+                        <div class="title">
+                            {{localize 'dishonored.actor.power.title'}}
                         </div>
-                        <div class="stat-flex-row sub-section-title">
-                            <div class="item-image"></div>
-                            <div class="item-name advisory">{{localize 'dishonored.actor.genericitem.name'}}</div>
-                            <a class="item-controls item-create add-item" title="Create item" data-type="power"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x1 bold">{{localize 'dishonored.actor.genericitem.name'}}</div>
+                            <a class="control create" title="Create item" data-type="power"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "power")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-name">{{item.name}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x1">{{item.name}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
@@ -185,86 +188,89 @@
                     </div>
                 </div>
                 <div class="column">
-                    <div class="belonging-section">
-                        <div class="belonging-title section-title item-section">
-                            <div class="title">{{localize 'dishonored.actor.belonging.title'}}</div>
+                    <div class="section belongings">
+                        <div class="title">
+                            {{localize 'dishonored.actor.belonging.title'}}
                         </div>
-                        <div class="sub-section-title item-section">
-                            <div class="collectables advisory">{{localize 'dishonored.actor.belonging.collectable.coin'}}</div>
-                            <div class="collectables"><input name="data.coins" type="text" value="{{data.coins}}" placeholder="0"/></div>
-                            <div class="collectables advisory">{{localize 'dishonored.actor.belonging.collectable.rune'}}</div>
-                            <div class="collectables"><input name="data.runes" type="text" value="{{data.runes}}" placeholder="0"/></div>
+                        <div class="row item">
+                            <div class="column-x4 bold">{{localize 'dishonored.actor.belonging.collectable.coin'}}</div>
+                            <div class="column-x4 small"><input name="data.coins" type="text" value="{{data.coins}}" placeholder="0"/></div>
+                            <div class="column-x4 bold">{{localize 'dishonored.actor.belonging.collectable.rune'}}</div>
+                            <div class="column-x4 small"><input name="data.runes" type="text" value="{{data.runes}}" placeholder="0"/></div>
                         </div>
-                        <div class="sub-section-title item-section">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.weapon.title'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.belonging.weapon.dmg'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="weapon"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.weapon.title'}}</div>
+                            <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.weapon.dmg'}}</div>
+                            <a class="control create" title="Create item" data-type="weapon"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "weapon")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <h4 class="item-two-section-sub">{{item.data.damage}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 class="column-x2-small">{{item.data.damage}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="sub-section-title item-section">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.armor.title'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.belonging.armor.protect'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="armor"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.armor.title'}}</div>
+                            <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.armor.protect'}}</div>
+                            <a class="control create" title="Create item" data-type="armor"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "armor")}}
-                        <li id="armor-{{item._id}}" class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <h4 id="protectval-armor-{{item._id}}" class="item-two-section-sub">{{item.data.protection}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li id="armor-{{item._id}}" class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 id="protectval-armor-{{item._id}}" class="column-x2-small">{{item.data.protection}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="sub-section-title item-section">
-                            <div class="item-image advisory">0/3</div>
-                            <div class="title advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image">
+                                <!-- 0/3 -->
+                            </div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
+                            <div class="column-x2-small advisory"></div>
+                            <a class="control create" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "bonecharm")}}
-                        <li class="item item-flex bonecharm" data-item-id="{{item._id}}" data-item-type="{{item.type}}" >
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-name">{{item.name}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry bonecharm" data-item-id="{{item._id}}" data-item-type="{{item.type}}" >
+                            <div class="image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x1">{{item.name}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="sub-section-title item-section">
-                            <div class="item-image"></div>
-                            <div class="item-two-section-main advisory">{{localize 'dishonored.actor.belonging.other.title'}}</div>
-                            <div class="item-two-section-sub advisory">{{localize 'dishonored.actor.belonging.other.qty'}}</div>
-                            <a class="item-controls item-create add-item-sub" title="Create item" data-type="item"><i class="fas fa-plus"></i></a>
+                        <div class="row item">
+                            <div class="image"></div>
+                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.other.title'}}</div>
+                            <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.other.qty'}}</div>
+                            <a class="control create" title="Create item" data-type="item"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "item")}}
-                        <li class="item item-flex" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
-                            <div class="item-image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
-                            <h4 class="item-two-section-main">{{item.name}}</h4>
-                            <h4 class="item-two-section-sub">{{item.data.quantity}}</h4>
-                            <div class="item-controls">
-                                <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                                <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
+                        <li class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                            <div class="image"><img class="cs-item-img" src="{{item.img}}" title="{{item.name}}"/></div>
+                            <h4 class="column-x2-big">{{item.name}}</h4>
+                            <h4 class="column-x2-small">{{item.data.quantity}}</h4>
+                            <div class="control">
+                                <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
+                                <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
@@ -273,14 +279,14 @@
                 </div>
             </div>
             <div class="row">
-                    <div class="note-npc-section">
-                        <div class="note-title section-title">
-                            {{localize 'dishonored.actor.note.title'}}
-                        </div>
-                        <div class="notes">
-                            {{editor content=data.notes target="data.notes" button=true owner=owner editable=editable}}
-                        </div>
+                <div class="section notes">
+                    <div class="title">
+                        {{localize 'dishonored.actor.note.title'}}
                     </div>
+                    <div class="notes">
+                        {{editor content=data.notes target="data.notes" button=true owner=owner editable=editable}}
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/items/armor-sheet.html
+++ b/templates/items/armor-sheet.html
@@ -1,22 +1,22 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-mini-main">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x3-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.belonging.armor.protection'}}</label>
                 <input type="text" name="data.protection" value="{{data.protection}}" data-dtype="Number" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.genericitem.cost'}}</label>
                 <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
             </div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/bonecharm-sheet.html
+++ b/templates/items/bonecharm-sheet.html
@@ -1,14 +1,14 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-single">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x1">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/contact-sheet.html
+++ b/templates/items/contact-sheet.html
@@ -1,12 +1,12 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-main">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x2-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input id="name" name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.contact.relation'}}</label>
                 <select class="relationship" name="data.relationship"  data-type="String">
                     {{#select item.data.relationship}}
@@ -18,10 +18,10 @@
             </div>
         </div>
         <div class="row">
-            <div class="send2actor-button">{{localize 'dishonored.item.contact.send2actor'}}</div>
+            <div class="send2actor btn">{{localize 'dishonored.item.contact.send2actor'}}</div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/focus-sheet.html
+++ b/templates/items/focus-sheet.html
@@ -1,18 +1,18 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-main">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x2-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.focus.rating'}}</label>
                 <input type="text" name="data.rating" value="{{data.rating}}" data-dtype="Number" />
             </div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/item-sheet.html
+++ b/templates/items/item-sheet.html
@@ -1,22 +1,22 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-mini-main">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x3-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.belonging.other.quantity'}}</label>
                 <input type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.genericitem.cost'}}</label>
                 <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
             </div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/power-sheet.html
+++ b/templates/items/power-sheet.html
@@ -1,22 +1,22 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-mini-main">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x3-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.power.mana'}}</label>
                 <input type="text" name="data.manacost" value="{{data.manacost}}" data-dtype="Number" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.power.rune'}}</label>
                 <input type="text" name="data.runecost" value="{{data.runecost}}" data-dtype="Number" />
             </div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/talent-sheet.html
+++ b/templates/items/talent-sheet.html
@@ -1,18 +1,18 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x2">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input">
+            <div class="column-x2">
                 <label>{{localize 'dishonored.actor.talent.type'}}</label>
                 <input type="text" name="data.type" value="{{data.type}}" />
             </div>
         </div>
     </div>
-        <div class="description">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>

--- a/templates/items/weapon-sheet.html
+++ b/templates/items/weapon-sheet.html
@@ -1,72 +1,72 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="header-fields">
         <div class="row">
-            <img class="item-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="item-header-input-main">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x2-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
             </div>
-            <div class="item-header-input-sub">
+            <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.genericitem.cost'}}</label>
                 <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
             </div>
         </div>
         <div class="row">
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="input" type="checkbox" name="data.qualities.armorpierce" data-dtype="Boolean" {{checked data.qualities.armorpierce}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.armorpierce'}}</label>
             </div>
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.awkward" data-dtype="Boolean" {{checked data.qualities.awkward}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.awkward'}}</label>
             </div>
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.blast" data-dtype="Boolean" {{checked data.qualities.blast}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.blast'}}</label>
             </div>
-            <div class="weapon-cell">
+            <div class="column-x4">
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.damage'}}</label>
                 <input type="text" name="data.damage" value="{{data.damage}}" data-dtype="Number" />
             </div>
         </div>
         <div class="row">
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.block" data-dtype="Boolean" {{checked data.qualities.block}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.block'}}</label>
             </div>
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.burn" data-dtype="Boolean" {{checked data.qualities.burn}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.burn'}}</label>
             </div>
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.concealed" data-dtype="Boolean" {{checked data.qualities.concealed}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.concealed'}}</label>
             </div>
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.melee" data-dtype="Boolean" {{checked data.qualities.melee}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.melee'}}</label>
             </div>
         </div>
         <div class="row">
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.messy" data-dtype="Boolean" {{checked data.qualities.messy}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.messy'}}</label>
             </div>
-            <div class="weapon-cell"> 
+            <div class="column-x4"> 
                 <input class="" type="checkbox" name="data.qualities.mine" data-dtype="Boolean" {{checked data.qualities.mine}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.mine'}}</label>
             </div>
-            <div class="weapon-cell">
+            <div class="column-x4">
                 <input class="" type="checkbox" name="data.qualities.rangeddistant" data-dtype="Boolean" {{checked data.qualities.rangeddistant}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.rangeddistant'}}</label>
             </div>
-            <div class="weapon-cell">
+            <div class="column-x4">
                 <input class="" type="checkbox" name="data.qualities.rangednearby" data-dtype="Boolean" {{checked data.qualities.rangednearby}}>
                 <label class="label">{{localize 'dishonored.actor.belonging.weapon.rangednearby'}}</label>
             </div>
         </div>
     </div>
-        <div class="description-weapon">
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
-        </div>
+    <div class="description">
+        {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+    </div>
 </form>


### PR DESCRIPTION
This one is a pretty behind the scenes update. No massive features unfortunately.
### Features/Bug Fixes
- Added a Limited Actor Sheet. When you have limited permissions to the actor you will now be shown a very cut down version of the sheet. (Closes #63 - thanks @kruvek) **NOTE**: currently items still are shown. This will be in the next update.
- Removed the parchment and replaced with a slightly off-white. This applies to all windows (except the roll dialog).
- Added a sticky header - with slight transparency. Now scrolling down the character sheet allows you to keep access to your momentum/experience.
- Improved general CSS experience. You may notice slightly visual changes - this is why. (closes #51)
- If you are not the owner of an actor you will no longer be shown which skill and style is selected (Resolved #64 - thanks also @kruvek).
- Any clickable items in the actor sheet when you are not the owner now no longer appear as clickable (fixes #33).
- Added _sick_ splash screen to the dev console. 
- Checked last few js scripts (ultimately they were basic enough for no comments required - fixes #53).