### PR TITLE
0.2.4 Chaotic Update

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -104,6 +104,9 @@
     "dishonored.roll.item.quantity": "|#|x Items",
 
 
+    "dishonored.tracker.chaos": "Chaos Tracker",
+
+
 
     "dishonored.__eof": "This is an end of file because I'm lazy and keep forgetting commas. This shouldn't be in the final commit (sorry if it is - see previous statement)."
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -79,6 +79,7 @@
     "dishonored.contact.relation.poor": "Poor",
     "dishonored.contact.relation.dire": "Dire",
 
+    "dishonored.item.armor.helmet": "Is Helmet?",
     "dishonored.item.contact.send2actor": "Send to Actor",
 
     "dishonored.apps.dicepoolwindow": "Dice Pool",

--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -95,6 +95,21 @@ export class DishonoredCharacterSheet extends ActorSheet {
         // We use i alot in for loops. Best to assign it now for use later in multiple places.
         var i;
 
+        // Here we are checking how many bonecharms, helmets and armors are equipped. 
+        // The player can only have three bonecharms, and one of each armor type. As such, we will use this later.
+        var bonecharmCount = 0;
+        var armorCount = 0;
+        var helmetCount = 0;
+        this.actor.items.forEach((values) => {
+            if (values.type == "bonecharm") bonecharmCount+= 1;
+        });
+        html.find('[name ="data.bonecharmequipped"]')[0].value = bonecharmCount;
+        // For ease of access we may as well turn the tooltip for bonecharm counts red.
+        if(bonecharmCount > 3) {
+            html.find('.bonecharmCount')[0].style.backgroundColor = "#fd0000";
+            html.find('.bonecharmCount')[0].style.color = "#ffffff";
+        }
+
         // This creates a dynamic Void Point tracker. It polls for the hidden control "max-void" and for the value, 
         // creates a new div for each and places it under a child called "bar-void-renderer"
         var voidPointsMax = html.find('#max-void')[0].value;
@@ -114,11 +129,10 @@ export class DishonoredCharacterSheet extends ActorSheet {
         for (i = 0; i < armor.length; i++) {
             stressTrackMax += parseInt(armor[i].innerHTML);
         }
-        // This checks that the max-stress hidden field is equal to the calculated Max Stress value, if not it makes it so and submits the form.
+        // This checks that the max-stress hidden field is equal to the calculated Max Stress value, if not it makes it so.
         if (html.find('#max-stress')[0].value != stressTrackMax)
         {
             html.find('#max-stress')[0].value = stressTrackMax;
-            this.submit();
         }
         for (i = 1; i <= stressTrackMax; i++) {
             var div = document.createElement("DIV");
@@ -212,6 +226,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
             event.preventDefault();
             const header = event.currentTarget;
             const type = header.dataset.type;
+            if (type == "bonecharm" && bonecharmCount >= 3) ui.notifications.warn("The current actor has 3 equipped bonecharms already.");
             const data = duplicate(header.dataset);
             const name = `New ${type.capitalize()}`;
             const itemData = {

--- a/module/actors/sheets/character-sheet.js
+++ b/module/actors/sheets/character-sheet.js
@@ -101,7 +101,7 @@ export class DishonoredCharacterSheet extends ActorSheet {
         var armorCount = 0;
         var helmetCount = 0;
         this.actor.items.forEach((values) => {
-            if (values.type == "bonecharm") bonecharmCount+= 1;
+            if (values.type == "bonecharm" && values.data.data.equipped == true) bonecharmCount+= 1;
         });
         html.find('[name ="data.bonecharmequipped"]')[0].value = bonecharmCount;
         // For ease of access we may as well turn the tooltip for bonecharm counts red.
@@ -189,11 +189,14 @@ export class DishonoredCharacterSheet extends ActorSheet {
             for (i = 0; i < html.find('.voidchange').length; i++) {
                 html.find('.voidchange')[i].style.display = 'none';
             }
-            // This hides all add and delete item images.
+            // This hides all toggle, add and delete item images.
             for (i = 0; i < html.find('.control.create').length; i++) {
                 html.find('.control.create')[i].style.display = 'none';
             }
             for (i = 0; i < html.find('.control.delete').length; i++) {
+                html.find('.control.delete')[i].style.display = 'none';
+            }
+            for (i = 0; i < html.find('.control.toggle').length; i++) {
                 html.find('.control.delete')[i].style.display = 'none';
             }
             // This hides all skill and style check boxes (and titles)
@@ -214,6 +217,23 @@ export class DishonoredCharacterSheet extends ActorSheet {
             return;
         };
 
+        // This toggles whether the item is equipped or not. Equipped items count towards item caps.
+        html.find('.control.toggle').click(ev => {
+            var itemType = $(ev.currentTarget).parents(".entry")[0].getAttribute("data-item-type");
+            var itemId = $(ev.currentTarget).parents(".entry")[0].getAttribute("data-item-id");
+            if (this.actor.items.get(itemId).data.data.equipped == true) {
+                this.actor.items.get(itemId).data.data.equipped = false;
+                this.submit();
+            }
+            else if (itemType == "bonecharm" && bonecharmCount >= 3) {
+                ui.notifications.error("The current actor has 3 equipped bonecharms already! Doing Nothing.");
+            }
+            else {
+                this.actor.items.get(itemId).data.data.equipped = true;
+                this.submit();
+            }
+        });
+
         // This allows for all items to be rolled, it gets the current targets type and id and sends it to the rollGenericItem function.
         html.find('.rollable').click(ev =>{
             var itemType = $(ev.currentTarget).parents(".entry")[0].getAttribute("data-item-type");
@@ -226,9 +246,13 @@ export class DishonoredCharacterSheet extends ActorSheet {
             event.preventDefault();
             const header = event.currentTarget;
             const type = header.dataset.type;
-            if (type == "bonecharm" && bonecharmCount >= 3) ui.notifications.warn("The current actor has 3 equipped bonecharms already.");
             const data = duplicate(header.dataset);
             const name = `New ${type.capitalize()}`;
+            console.log(data);
+            if (type == "bonecharm" && bonecharmCount >= 3) {
+                ui.notifications.info("The current actor has 3 equipped bonecharms already. Adding unequipped.");
+                data.equipped = false;
+            }
             const itemData = {
                 name: name,
                 type: type,

--- a/module/apps/tracker.js
+++ b/module/apps/tracker.js
@@ -1,0 +1,87 @@
+export class DishonoredTracker extends Application {
+
+    static get defaultOptions() {
+        const options = super.defaultOptions;
+        options.template = "systems/FVTT-Dishonored/templates/apps/tracker.html";
+        options.popOut = false;
+        options.resizable = false;
+        return options;
+    }
+    
+    activateListeners(html) {
+        let stat = game.settings.get("FVTT-Dishonored", "stat");
+        renderTracker()
+        this.checkUpdates();
+
+        if (!game.user.hasRole(game.settings.get("FVTT-Dishonored", "trackerPermissionLevel"))) {
+            html.find('.dishonored-impermitable')[0].style.display = 'none';
+            html.find('.dishonored-impermitable')[1].style.display = 'none';
+            html.find('#dishonored-track-stat')[0].disabled = true;
+            return false;
+        }
+
+        html.find('#dishonored-track-decrease').click(ev => {
+            stat = parseInt(document.getElementById("dishonored-track-stat").value);
+            if (stat===0) {
+                ui.notifications.warn("You can't set Chaos to a value below 0!");
+                return false;
+            }
+            stat = stat - 1;
+            game.settings.set("FVTT-Dishonored", "stat",stat);
+            renderTracker();
+        });
+
+        html.find('#dishonored-track-increase').click(ev => {
+            if (stat===99999999) {
+                ui.notifications.error("THERE IS TOO MUCH CHAOS!");
+                return false;
+            }
+            stat = parseInt(document.getElementById("dishonored-track-stat").value);
+            stat = stat + 1;
+            game.settings.set("FVTT-Dishonored", "stat",stat);
+            renderTracker();
+        });
+
+        html.find('#dishonored-track-stat').keydown(ev => {
+            if (ev.keyCode == 13) {
+                html.find('#dishonored-track-stat').blur();
+            }   
+        })
+
+        html.find('#dishonored-track-stat').change(ev => {
+            if (document.getElementById("dishonored-track-stat").value < 0) {
+                document.getElementById("dishonored-track-stat").value = stat;
+                ui.notifications.warn("You can't set Chaos to a value below 0!");
+                return false;
+            }
+            if (document.getElementById("dishonored-track-stat").value > 99999999) {
+                document.getElementById("dishonored-track-stat").value = stat;
+                ui.notifications.error("THAT IS TOO MUCH CHAOS!");
+                return false;
+            }
+            stat = document.getElementById("dishonored-track-stat").value;
+            game.settings.set("FVTT-Dishonored", "stat", stat);
+            renderTracker();
+        });
+
+        function renderTracker() {
+            document.getElementById("dishonored-track-stat").value = stat;
+        }
+
+    }
+
+    async checkUpdates(stat) {
+        let refreshRate = game.settings.get("FVTT-Dishonored", "trackerRefreshRate") * 1000;
+        function check() {
+            let stat = document.getElementById("dishonored-track-stat").value;
+            let storedStat = game.settings.get("FVTT-Dishonored", "stat");
+            if ($("#dishonored-track-stat").is(':focus') == false) {
+                if (storedStat != stat) {
+                    document.getElementById("dishonored-track-stat").value = storedStat;
+                }
+            }
+            setTimeout(check, refreshRate);
+        }
+        check();
+    }
+}

--- a/module/dishonored.js
+++ b/module/dishonored.js
@@ -32,12 +32,17 @@ import {
 import {
     DishonoredPowerSheet
 } from "./items/power-sheet.js";
+import { 
+    DishonoredTracker 
+} from "./apps/tracker.js";
+import * as macros 
+from "./macro.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
 /* -------------------------------------------- */
 
-Hooks.once("init", async function() {
+Hooks.once("init", function() {
     // Splash Screen
     console.log(`Initializing Dishonored Tabletop Roleplaying Game System
                                                             @@
@@ -63,6 +68,28 @@ Hooks.once("init", async function() {
                                                 @@@
                                                    @@@
                                                       @@`)
+
+
+    // Create a namespace within the game global
+    game.dishonored = {
+        applications: {
+            DishonoredCharacterSheet,
+            DishonoredNPCSheet,
+            DishonoredItemSheet,
+            DishonoredFocusSheet,
+            DishonoredBonecharmSheet,
+            DishonoredWeaponSheet,
+            DishonoredArmorSheet,
+            DishonoredTalentSheet,
+            DishonoredContactSheet,
+            DishonoredPowerSheet,
+        },
+        entities: {
+            DishonoredActor,
+        },
+        macros: macros,
+        skillTest: macros.skillTest
+    };
 
     // Define initiative for the system.
     CONFIG.Combat.initiative = {
@@ -135,6 +162,22 @@ Hooks.once("init", async function() {
         }
     });
 
+    game.settings.register("FVTT-Dishonored", "trackerPermissionLevel", {
+        name: 'Tracker User Role:',
+        hint: 'Who should be allowed to amend the tracker?',
+        scope: "world",
+        type: String,
+        default: "ASSISTANT",
+        config: true,
+        choices: {
+          "NONE": "Switch Off Send2Actor",
+          "PLAYER": "Players",
+          "TRUSTED": "Trusted Players",
+          "ASSISTANT": "Assistant Gamemaster",
+          "GAMEMASTER": "Gamemasters",
+        }
+    });
+
     game.settings.register("FVTT-Dishonored", "maxNumberOfExperience", {
         name: 'Maximum amount of Experience:',
         hint: 'Max number of experience that can be given to a character. 30 is default, anything past 50 becomes almost unreadable.',
@@ -142,5 +185,28 @@ Hooks.once("init", async function() {
         type: Number,
         default: 30,
         config: true
+    });
+
+    game.settings.register("FVTT-Dishonored", "trackerRefreshRate", {
+        name: 'Refresh Rate of Chaos Tracker:',
+        hint: 'In seconds, how often should the tracker refresh. It is inadvisable to set this too low. Up this if it appears to be causing optimisation issues.',
+        scope: "world",
+        type: Number,
+        default: 5,
+        config: true
+    });
+
+    game.settings.register("FVTT-Dishonored", "stat", {
+        scope: "world",
+        type: Number,
+        default: 0,
+        config: false
+    });
+
+    Hooks.on("ready", function() {
+        let t = new DishonoredTracker()
+        renderTemplate("systems/FVTT-Dishonored/templates/apps/tracker.html").then(html => {
+            t.render(true);
+        });
     });
 });

--- a/module/items/armor-sheet.js
+++ b/module/items/armor-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredArmorSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "armor"],
-            template: "systems/FVTT-Dishonored/templates/items/armor-sheet.html",
             width: 500,
             height: 250,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/armor-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/bonecharm-sheet.js
+++ b/module/items/bonecharm-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredBonecharmSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "bonecharm"],
-            template: "systems/FVTT-Dishonored/templates/items/bonecharm-sheet.html",
             width: 500,
             height: 250,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/bonecharm-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/contact-sheet.js
+++ b/module/items/contact-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredContactSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "contact"],
-            template: "systems/FVTT-Dishonored/templates/items/contact-sheet.html",
             width: 500,
             height: 400,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/contact-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/focus-sheet.js
+++ b/module/items/focus-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredFocusSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "focus"],
-            template: "systems/FVTT-Dishonored/templates/items/focus-sheet.html",
             width: 500,
             height: 200,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/focus-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/item-sheet.js
+++ b/module/items/item-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredItemSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "item"],
-            template: "systems/FVTT-Dishonored/templates/items/item-sheet.html",
             width: 500,
             height: 480,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/item-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/power-sheet.js
+++ b/module/items/power-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredPowerSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "power"],
-            template: "systems/FVTT-Dishonored/templates/items/power-sheet.html",
             width: 500,
             height: 250,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/power-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/talent-sheet.js
+++ b/module/items/talent-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredTalentSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "talent"],
-            template: "systems/FVTT-Dishonored/templates/items/talent-sheet.html",
             width: 500,
             height: 250,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/talent-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/items/weapon-sheet.js
+++ b/module/items/weapon-sheet.js
@@ -4,12 +4,23 @@ export class DishonoredWeaponSheet extends ItemSheet {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
             classes: ["dishonored", "sheet", "item", "weapon"],
-            template: "systems/FVTT-Dishonored/templates/items/weapon-sheet.html",
             width: 565,
             height: 400,
             tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }]
         });
     }
+
+    /* -------------------------------------------- */
+
+    // If the player is not a GM and has limited permissions - send them to the limited sheet, otherwise, continue as usual.
+    /** @override */
+    get template() {
+        if ( !game.user.isGM && this.item.limited) {
+	        ui.notifications.warn("You do not have permission to view this item!");
+            return;
+        }
+        return `systems/FVTT-Dishonored/templates/items/weapon-sheet.html`;
+      }
 
     /* -------------------------------------------- */
 

--- a/module/macro.js
+++ b/module/macro.js
@@ -1,0 +1,45 @@
+import {
+    DishonoredRoll
+} from './roll.js'
+
+export function skillTest(actor, skillName, styleName, focusRating, numberOfDice) {
+    let fail = false;  
+    if (actor === undefined) {
+        ui.notifications.warn("Please provide an actor to the macro!");
+        fail = true;
+    }
+    if (skillName === undefined) {
+        ui.notifications.warn("Please provide an skill to the macro!");
+        fail = true;
+    }
+    if (styleName === undefined) {
+        ui.notifications.warn("Please provide an style to the macro!");
+        fail = true;
+    }
+    if (focusRating < 1) {
+        ui.notifications.warn("Focus cannot be less than 1!");
+        fail = true;
+    }
+    if (numberOfDice > 5) {
+        ui.notifications.warn("You cannot roll more than 5 die!");
+        fail = true;
+    }
+    else if (numberOfDice < 1) {
+        ui.notifications.warn("You must roll a dice!");
+        fail = true;
+    }
+    if (fail === true) {
+        return false;
+    }
+    if (numberOfDice === undefined) {
+        numberOfDice = 2;
+    }
+    if (focusRating === undefined) {
+        focusRating = 1;
+    }
+    let skillValue = parseInt(actor.data.data.skills[skillName].value);
+    let styleValue = parseInt(actor.data.data.styles[styleName].value);
+    let dishonoredRoll = new DishonoredRoll();
+    dishonoredRoll.performSkillTest(numberOfDice, skillValue+styleValue, focusRating, skillName, styleName, actor);
+}
+  

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -437,3 +437,45 @@
     border-radius: 3px;
     background-color: rgb(255, 255, 255, 0.3);
 }
+
+
+
+/* Tracker - Generic */
+
+.dishonored.tracker {
+    position: absolute;
+    display: block;
+    width: 200px;
+    height: 80px;
+    bottom: 0;
+    right: 304px;
+    margin: 5px;
+    margin-right: 0;
+    border: 1px solid black;
+}
+
+.dishonored.tracker .header {
+    text-align: center;
+    font-size: 1.75em;
+    text-transform: uppercase;
+    padding-bottom: 5px;
+}
+
+.dishonored.tracker .button-group {
+    display: flex;
+    font-size: 1.5em;
+}
+
+.dishonored.tracker .button-group .button {
+    padding: 0 10px;
+    cursor: pointer;
+}
+
+.dishonored.tracker .button-group .button:hover {
+    text-shadow: 0 0 8px red;
+}
+
+.dishonored.tracker .button-group .input {
+    color: white;
+    text-align: center;
+}

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -125,6 +125,13 @@
     overflow-y: auto;
 }
 
+.dishonored.sheet.actor .main .row .column .section .profile-img {
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    object-position: 50% 0;
+}
+
 .dishonored.sheet.actor .main .row .column .section .title {
     font-size: 18pt;
     font-weight: bold;
@@ -207,8 +214,10 @@
 }
 
 .dishonored.sheet.actor .main .row .column .section .row .image img {
-    max-height: 24px;
-    max-width: 24px;
+    width: 24px;
+    height: 24px;
+    object-fit: cover;
+    object-position: 50% 0;
 }
 
 .dishonored.sheet.actor .main .row .column .section .row .image .rollable:hover {
@@ -253,6 +262,16 @@
 
 
 
+/* Actor - Main Section - Specific - Bonecharm Specific */
+
+.dishonored.sheet.actor .main .row .column .section.belongings .row .bonecharm input {
+    padding: 0;
+    min-width: 0;
+    width: 10px
+}
+
+
+
 /* Item - Globals */
 
 .dishonored.sheet.item .header-fields {
@@ -262,6 +281,9 @@
 
 .dishonored.sheet.item .header-fields .row .img {
     width: 50px;
+    height: 50px;
+    object-fit: cover;
+    object-position: 50% 0;
 }
 
 .dishonored.sheet.item .header-fields .row .column-x3-big {

--- a/styles/dishonored.css
+++ b/styles/dishonored.css
@@ -262,6 +262,30 @@
 
 
 
+/* Actor - Main Section - Specific - Equipable Specific */
+
+.dishonored.sheet.actor .main .row .column .section .row.equipable .control {
+    width: 56px;
+}
+
+.dishonored.sheet.actor .main .row .column .section .row.equipable .column-x1 {
+    width: calc(100% - 80px);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row.equipable .column-x2 {
+    width: calc((100% - 80px)/2);
+}
+
+.dishonored.sheet.actor .main .row .column .section .row.equipable .column-x2-big {
+    width: calc(3*((100% - 80px)/4));
+}
+
+.dishonored.sheet.actor .main .row .column .section .row .equipable.column-x2-small {
+    width: calc((100% - 80px)/4);
+}
+
+
+
 /* Actor - Main Section - Specific - Bonecharm Specific */
 
 .dishonored.sheet.actor .main .row .column .section.belongings .row .bonecharm input {
@@ -284,6 +308,9 @@
     height: 50px;
     object-fit: cover;
     object-position: 50% 0;
+}
+.dishonored.sheet.item .header-fields .row .column-x3-big {
+    width: calc(40% - 50px);
 }
 
 .dishonored.sheet.item .header-fields .row .column-x3-big {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "FVTT-Dishonored",
     "title": "Dishonored Roleplaying Game Unofficial",
     "description": "An unofficial rendition of the Modiphius tabletop role playing game system.",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.7.0",
     "templateVersion": 1,

--- a/system.json
+++ b/system.json
@@ -4,7 +4,7 @@
     "description": "An unofficial rendition of the Modiphius tabletop role playing game system.",
     "version": "0.2.4",
     "minimumCoreVersion": "0.6.4",
-    "compatibleCoreVersion": "0.7.0",
+    "compatibleCoreVersion": "0.6.5",
     "templateVersion": 1,
     "author": "KaitoR95",
     "esmodules": ["module/dishonored.js"],

--- a/template.json
+++ b/template.json
@@ -95,7 +95,8 @@
                 "max": 6
             },
             "coins": 0,
-            "runes": 0
+            "runes": 0,
+            "bonecharmequipped": 0
         },
         "npc": {
             "templates": ["common"]

--- a/template.json
+++ b/template.json
@@ -119,7 +119,8 @@
             "rating": 2
         },
         "bonecharm": {
-            "templates": ["common"]
+            "templates": ["common"],
+            "equipped": true
         },
         "weapon": {
             "templates": ["common"],
@@ -142,7 +143,9 @@
         "armor": {
             "templates": ["common"],
             "protection": 0,
-            "cost": 0
+            "cost": 0,
+            "helmet": false,
+            "equipped": true
         },
         "talent": {
             "templates": ["common"],

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -152,7 +152,7 @@
                     </div>
                     <div class="separator"></div>
                     <div class="section img">
-                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
+                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
                     </div>
                     <div class="separator"></div>
                     <div class="section void">
@@ -361,11 +361,10 @@
                         {{/if}}
                         {{/each}}
                         <div class="row item">
-                            <div class="image">
-                                <!-- 0/3 -->
+                            <div class="image bonecharmCount">
+                                <span class="small bonecharm disabled"><input name="data.bonecharmequipped" type="text" value="{{data.bonecharmequipped}}" readonly/></span>/3
                             </div>
-                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
-                            <div class="column-x2-small advisory"></div>
+                            <div class="column-x1">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
                             <a class="control create" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}

--- a/templates/actors/character-sheet.html
+++ b/templates/actors/character-sheet.html
@@ -341,7 +341,7 @@
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="row item">
+                        <div class="row item equipable">
                             <div class="image"></div>
                             <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.armor.title'}}</div>
                             <div class="column-x2-small advisory">{{localize 'dishonored.actor.belonging.armor.protect'}}</div>
@@ -349,18 +349,19 @@
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "armor")}}
-                        <li id="armor-{{item._id}}" class="row entry" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
+                        <li id="armor-{{item._id}}" class="row entry equipable" data-item-id="{{item._id}}" data-item-type="{{item.type}}">
                             <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
                             <h4 class="column-x2-big">{{item.name}}</h4>
                             <h4 id="protectval-armor-{{item._id}}" class="column-x2-small">{{item.data.protection}}</h4>
                             <div class="control">
+                                <!-- <a class="control toggle""><i class="fas fa-toggle-{{#if (eq item.data.equipped true)}}on{{else}}off{{/if}}"></i></a> -->
                                 <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                                 <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>
                         </li>
                         {{/if}}
                         {{/each}}
-                        <div class="row item">
+                        <div class="row item equipable">
                             <div class="image bonecharmCount">
                                 <span class="small bonecharm disabled"><input name="data.bonecharmequipped" type="text" value="{{data.bonecharmequipped}}" readonly/></span>/3
                             </div>
@@ -369,10 +370,11 @@
                         </div>
                         {{#each actor.items as |item type id|}}
                         {{#if (eq item.type "bonecharm")}}
-                        <li class="row entry bonecharm" data-item-id="{{item._id}}" data-item-type="{{item.type}}" >
+                        <li class="row entry bonecharm equipable" data-item-id="{{item._id}}" data-item-type="{{item.type}}" >
                             <div class="image"><img class="rollable" src="{{item.img}}" title="{{item.name}}"/></div>
                             <h4 class="column-x1">{{item.name}}</h4>
                             <div class="control">
+                                <a class="control toggle""><i class="fas fa-toggle-{{#if (eq item.data.equipped true)}}on{{else}}off{{/if}}"></i></a>
                                 <a class="control edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                                 <a class="control delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                             </div>

--- a/templates/actors/limited-sheet.html
+++ b/templates/actors/limited-sheet.html
@@ -27,8 +27,8 @@
                 <div class="column">
                 </div>
                 <div class="column">
-                    <div class="img-section">
-                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
+                    <div class="section img">
+                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
                     </div>
                 </div>
                 <div class="column">

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -238,10 +238,8 @@
                         {{/each}}
                         <div class="row item">
                             <div class="image">
-                                <!-- 0/3 -->
                             </div>
-                            <div class="column-x2-big advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
-                            <div class="column-x2-small advisory"></div>
+                            <div class="column-x1 advisory">{{localize 'dishonored.actor.belonging.bonecharm.title'}}</div>
                             <a class="control create" title="Create item" data-type="bonecharm"><i class="fas fa-plus"></i></a>
                         </div>
                         {{#each actor.items as |item type id|}}

--- a/templates/actors/npc-sheet.html
+++ b/templates/actors/npc-sheet.html
@@ -110,7 +110,7 @@
                     </div>
                     <div class="separator"></div>
                     <div class="section img">
-                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="150" width="150" />
+                        <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" />
                     </div>
                     <div class="separator"></div>
                     <div class="check-button btn">{{localize 'dishonored.actor.skisty.check'}}</div>

--- a/templates/apps/tracker.html
+++ b/templates/apps/tracker.html
@@ -1,0 +1,16 @@
+<div id="dishonored-tracker" class="dishonored tracker app">
+    <div class="header">
+        {{localize 'dishonored.tracker.chaos'}}
+    </div>
+    <div class="button-group">
+        <div id="dishonored-track-decrease" class="button dishonored-impermitable">
+            <i class="fas fa-minus"></i>
+        </div>
+        <div>
+            <input type="text" class="input" id="dishonored-track-stat" data-dtype="Number" />
+        </div>
+        <div id="dishonored-track-increase" class="button dishonored-impermitable">
+            <i class="fas fa-plus"></i>
+        </div>
+    </div>
+</div>

--- a/templates/items/armor-sheet.html
+++ b/templates/items/armor-sheet.html
@@ -2,9 +2,13 @@
     <div class="header-fields">
         <div class="row">
             <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-            <div class="column-x3-big">
+            <div class="column-x4-big">
                 <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
                 <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
+            </div>
+            <div class="column-x2-x3-small">
+                <label>{{localize 'dishonored.item.armor.helmet'}}</label>
+                <input class="" type="checkbox" name="data.helmet" data-dtype="Boolean" {{checked data.helmet}}>
             </div>
             <div class="column-x2-x3-small">
                 <label>{{localize 'dishonored.actor.belonging.armor.protection'}}</label>

--- a/templates/items/limited-sheet.html
+++ b/templates/items/limited-sheet.html
@@ -1,0 +1,11 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="header-fields">
+        <div class="row">
+            <img class="img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+            <div class="column-x1">
+                <label>{{localize 'dishonored.actor.genericitem.name'}}</label>
+                <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
+            </div>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
After a little hiatus, back to looking at this again.

Decided to get some pretty big features pushed out the door (hopefully to make it playable this week!):
- Made a limited Items sheet. Essentially meaning those with limited permissions can only see basics (closes #67)
- Added an Is Helmet tag (closes #58 - Thanks @Kruvek)
- Added a limit to the number of bonecharms one can actively equip (closes #27). Have added an equip/unequip button to manage this. Adding new bonecharms when at the limit will result in the new one being added unequipped.
- Added a Chaos Tracker. This is hard defined in the bottom right (near the chat entry). Added a system setting to defined the refresh interval for this (5 seconds - this is probably the lowest it should be set...). Also added a permission for who can change the Chaos Track. Default Assistant GM+ (closes #18).
- Added a basic Macro that perform's a skill test. #12 has some basic details on the structure of the macro. Creating issue #69 for improvement of this feature. (closes #12)
